### PR TITLE
feat: add Angular ESLint with zero-warning enforcement

### DIFF
--- a/Gridly-Client/angular.json
+++ b/Gridly-Client/angular.json
@@ -94,6 +94,16 @@
             ],
             "scripts": []
           }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "maxWarnings": 0,
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
+          }
         }
       }
     }

--- a/Gridly-Client/eslint.config.js
+++ b/Gridly-Client/eslint.config.js
@@ -1,0 +1,44 @@
+// @ts-check
+const eslint = require("@eslint/js");
+const { defineConfig } = require("eslint/config");
+const tseslint = require("typescript-eslint");
+const angular = require("angular-eslint");
+
+module.exports = defineConfig([
+  {
+    files: ["**/*.ts"],
+    extends: [
+      eslint.configs.recommended,
+      tseslint.configs.recommended,
+      tseslint.configs.stylistic,
+      angular.configs.tsRecommended,
+    ],
+    processor: angular.processInlineTemplates,
+    rules: {
+      "@angular-eslint/directive-selector": [
+        "error",
+        {
+          type: "attribute",
+          prefix: "app",
+          style: "camelCase",
+        },
+      ],
+      "@angular-eslint/component-selector": [
+        "error",
+        {
+          type: "element",
+          prefix: "app",
+          style: "kebab-case",
+        },
+      ],
+    },
+  },
+  {
+    files: ["**/*.html"],
+    extends: [
+      angular.configs.templateRecommended,
+      angular.configs.templateAccessibility,
+    ],
+    rules: {},
+  }
+]);

--- a/Gridly-Client/package.json
+++ b/Gridly-Client/package.json
@@ -3,6 +3,7 @@
   "version": "v1.1.6-alpha",
   "scripts": {
     "build": "ng build",
+    "lint": "ng lint",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "node-run": "node dist/gridly-client/server/server.mjs",
@@ -25,6 +26,10 @@
     "zone.js": "^0.15.1"
   },
   "devDependencies": {
-    "@angular/cli": "^21.2.1"
+    "@angular/cli": "^21.2.1",
+    "@eslint/js": "^10.0.1",
+    "angular-eslint": "^21.3.1",
+    "eslint": "^10.2.1",
+    "typescript-eslint": "^8.59.0"
   }
 }

--- a/Gridly-Client/src/app/Components/Grid/grid.component.html
+++ b/Gridly-Client/src/app/Components/Grid/grid.component.html
@@ -2,7 +2,7 @@
   <div class="grid-layout" cdkDropList cdkDropListOrientation="horizontal" (cdkDropListDropped)="Drop($event)">
     @for(component of components; track component) {
     <div class="shadow-sm grid-item-style" cdkDrag [cdkDragDisabled]="!inEditMode" [id]="component.id.toString()">
-      <item-component [id]="component.id"></item-component>
+      <app-item [id]="component.id"></app-item>
     </div>
     }
   </div>

--- a/Gridly-Client/src/app/Components/Grid/grid.component.ts
+++ b/Gridly-Client/src/app/Components/Grid/grid.component.ts
@@ -1,38 +1,39 @@
-import { Component, inject, Renderer2} from '@angular/core';
-import { CommonModule} from '@angular/common';
+import { Component, inject, Renderer2 } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { ComponentService } from "../../Services/component.service";
 import { ItemComponent } from "../Item/item.component";
 import { CdkDrag, CdkDragDrop, CdkDropList, moveItemInArray } from "@angular/cdk/drag-drop";
 import { ComponentModel } from '../../Models/Component.Model';
 import { GridService } from '../../Services/grid.service';
 @Component({
-  selector: 'grid-component',
+  selector: 'app-grid',
   imports: [CommonModule, CdkDropList, CdkDrag, ItemComponent],
   templateUrl: './grid.component.html',
   standalone: true,
   styleUrls: ['./grid.component.css'],
 })
 
-export class GridComponent{
+export class GridComponent {
+  private render = inject(Renderer2);
 
   #componentService = inject(ComponentService);
   #gridService = inject(GridService);
-  
+
   components$ = this.#componentService.components$;
-  
+
   inEditMode!: boolean;
 
-  constructor(private render: Renderer2) {
+  constructor() {
     this.inEditMode = this.#gridService.getEditMode();
     this.SetLayout();
   }
 
   protected Drop(event: CdkDragDrop<ComponentModel[]>): void {
     if (!this.inEditMode) return;
-        moveItemInArray(event.item.data, event.previousIndex, event.currentIndex);
+    moveItemInArray(event.item.data, event.previousIndex, event.currentIndex);
   }
 
-  protected SetLayout() {
+  protected SetLayout(): void {
     /*for (const item of this.components) {
       const el = document.getElementById(item.id.toString());
       if(el) {

--- a/Gridly-Client/src/app/Components/Header/header.component.html
+++ b/Gridly-Client/src/app/Components/Header/header.component.html
@@ -15,11 +15,11 @@
               <i class="bi bi-plus-lg me-1"></i>
               <span>{{TextStringsUtil.MenuAddWidgetButtonTitle}}</span>
             </button>
-            <add-widget-modal
+            <app-add-widget-modal
               [(open)]="addWidgetDialogActive"
               [widgetOptions]="widgetOptions"
               (newWidget)="add($event)">
-            </add-widget-modal>
+            </app-add-widget-modal>
           </li>
            <li class="nav-item">
              <button class="btn btn-primary btn-sm d-flex align-items-center gap-1"

--- a/Gridly-Client/src/app/Components/Header/header.component.ts
+++ b/Gridly-Client/src/app/Components/Header/header.component.ts
@@ -1,14 +1,15 @@
-import {Component, inject, OnInit, signal} from "@angular/core";
-import {TextStringsUtil} from "../../Constants/text.strings.util";
-import {CommonModule} from "@angular/common";
-import {VersionService} from "../../Services/version.service";
-import {AddWidgetModalComponent} from "../ModalComponents/AddWidgetModal/add-widget-modal.component";
+import { Component, inject, signal } from "@angular/core";
+import { TextStringsUtil } from "../../Constants/text.strings.util";
+import { CommonModule } from "@angular/common";
+import { VersionService } from "../../Services/version.service";
+import { AddWidgetModalComponent } from "../ModalComponents/AddWidgetModal/add-widget-modal.component";
 import { WidgetType } from "../../Types/widget.type.enum";
 import { ComponentModel } from "../../Models/Component.Model";
 import { ComponentService } from "../../Services/component.service";
+import { GridService } from "../../Services/grid.service";
 
 @Component({
-  selector: 'header-component',
+  selector: 'app-header',
   templateUrl: './header.component.html',
   styleUrl: './header.component.css',
   standalone: true,
@@ -18,6 +19,7 @@ export class HeaderComponent {
 
   #componentService = inject(ComponentService);
   #versionService = inject(VersionService);
+  #gridService = inject(GridService);
 
   component$ = this.#componentService.component$;
   version$ = this.#versionService.version$;
@@ -30,7 +32,7 @@ export class HeaderComponent {
   protected widgetOptions = [
     { type: WidgetType.Empty, label: 'Add empty widget', description: '', icon: 'bi bi-box' },
     { type: WidgetType.Custom, label: 'Add custom widget', description: '', icon: 'bi bi-box-fill' },
-  ]
+  ];
 
 
   /* TODO variants later maybe
@@ -48,8 +50,8 @@ export class HeaderComponent {
 
   //componentService.EditComponentsData(componentService.Components)
   //TODO get all components and activate edit mode
-  protected setEditMode(){
-    
+  protected setEditMode(): void {
+    this.#gridService.toggle();
   }
 
   toggleMenu(): void {

--- a/Gridly-Client/src/app/Components/Item/item.component.html
+++ b/Gridly-Client/src/app/Components/Item/item.component.html
@@ -25,7 +25,7 @@
       </div>
       <div class="col d-flex justify-content-end">
         <button
-        makeResizable
+        appMakeResizable
         [canResize]="inEditMode"
         [targetId]="component.id"
         type="button"
@@ -46,18 +46,18 @@
         <h5 class="fw-bold">{{TextStringsUtil.EmptyWidgetTitle}}</h5>
         <p [hidden]="component?.componentSettings?.titleHidden" class="text-center" >{{component?.name}}</p>
       </a>
-  <edit-widget-modal 
+  <app-edit-widget-modal
     [open]="isEditModalOpen"
     [modalId]="component.id"
     [id]="component.id"
     (editedComponent)="edit(component)"
     (openChange)="handleModalChange($event)">
-  </edit-widget-modal>
-  <prompt-modal
+  </app-edit-widget-modal>
+  <app-prompt-modal
     [open]="isDeleteModalOpen"
     [modalId]="component.id"
     [id]="component.id"
     (remove)="remove(component.id)"
     (openChange)="handleModalChange($event)">
-  </prompt-modal>
+  </app-prompt-modal>
 }

--- a/Gridly-Client/src/app/Components/Item/item.component.ts
+++ b/Gridly-Client/src/app/Components/Item/item.component.ts
@@ -11,14 +11,14 @@ import { MatIconModule } from '@angular/material/icon';
 import { GridService } from '../../Services/grid.service';
 
 @Component({
-  selector: 'item-component',
+  selector: 'app-item',
   templateUrl: './item.component.html',
   styleUrl: './item.component.css',
   standalone: true,
   imports: [
     CommonModule,
     CdkDragHandle,
-    PromptModalComponent,   
+    PromptModalComponent,
     EditWidgetModalComponent,
     ResizableDirective,
     MatIconModule
@@ -34,18 +34,14 @@ export class ItemComponent {
   #gridService = inject(GridService);
 
   component$ = this.#componentService.component$;
-   
-  isEditModalOpen: boolean = false;
-  isDeleteModalOpen: boolean = false;
+
+  isEditModalOpen = false;
+  isDeleteModalOpen = false;
   inEditMode = this.#gridService.getEditMode();
 
   protected IconFilePath(item: ComponentModel): string {
     return 'Assets/Icons/' + item.iconData?.name + '.' + item.iconData?.type;
   }
-   protected handleSelect(t: any) {
-    this.#componentService.edit(t);
-  }
-
   handleModalChange(modalId: number): void {
     if (modalId === this.id) {
       this.isEditModalOpen = false;
@@ -57,16 +53,16 @@ export class ItemComponent {
     this.#componentService.edit(component);
   }
 
-  protected remove(id: number ) {
+  protected remove(id: number) {
     this.#componentService.delete(id);
   }
 
   openEditDialog(): void {
-        //TODO make dialog class and open dialog here
+    this.isEditModalOpen = true;
   }
 
   openDeleteDialog(): void {
-    //TODO make dialog class and open dialog here
+    this.isDeleteModalOpen = true;
   }
 
   protected readonly TextStringsUtil = TextStringsUtil;

--- a/Gridly-Client/src/app/Components/ModalComponents/AddWidgetModal/add-widget-modal.component.html
+++ b/Gridly-Client/src/app/Components/ModalComponents/AddWidgetModal/add-widget-modal.component.html
@@ -1,5 +1,5 @@
-<dialog modalWindow [open]="open" (openChange)="handleOpenChange($event)" #dlg class="aw-dialog" (click)="onBackdropClick($event)" aria-labelledby="aw-title">
-  <div class="aw-card" (click)="$event.stopPropagation()">
+<dialog appModalWindow [open]="open" (openChange)="handleOpenChange()" #dlg class="aw-dialog" aria-labelledby="aw-title">
+  <div class="aw-card">
     <header class="aw-header">
       <h5 id="aw-title" class="m-0">{{ TextStringsUtil.AddWidgetTitle }}</h5>
       <button type="button" class="btn" aria-label="Close" (click)="close()">

--- a/Gridly-Client/src/app/Components/ModalComponents/AddWidgetModal/add-widget-modal.component.ts
+++ b/Gridly-Client/src/app/Components/ModalComponents/AddWidgetModal/add-widget-modal.component.ts
@@ -1,21 +1,12 @@
-import {
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  AfterViewInit,
-  OnChanges,
-  SimpleChanges,
-} from '@angular/core';
+import { Component, Input, Output, EventEmitter, AfterViewInit, OnChanges, SimpleChanges } from '@angular/core';
 import { ModalDirective } from '../../../Directives/modal.directive';
 import { BaseModalComponent } from '../../../Directives/base-modal.component';
-import { ModalService } from '../../../Services/modal.service';
 import { WidgetType } from '../../../Types/widget.type.enum';
 import { WidgetOptionsModal } from '../../../Models/WidgetOptionsModal';
 import { ComponentModel } from '../../../Models/Component.Model';
 
 @Component({
-  selector: 'add-widget-modal',
+  selector: 'app-add-widget-modal',
   standalone: true,
   imports: [ModalDirective],
   templateUrl: './add-widget-modal.component.html',
@@ -25,15 +16,11 @@ export class AddWidgetModalComponent
   extends BaseModalComponent
   implements AfterViewInit, OnChanges
 {
-  @Input() open: boolean = false;
+  @Input() open = false;
   @Input() widgetOptions: WidgetOptionsModal[] = [];
 
   @Output() openChange = new EventEmitter<boolean>();
   @Output() newWidget = new EventEmitter<ComponentModel>();
-
-  constructor(modalService: ModalService) {
-    super(modalService);
-  }
 
   ngAfterViewInit(): void {
     if (this.modalDirective) {
@@ -49,7 +36,7 @@ export class AddWidgetModalComponent
     }
   }
 
-  handleOpenChange(modalId: number): void {
+  handleOpenChange(): void {
     this.openChange.emit(false);
   }
 

--- a/Gridly-Client/src/app/Components/ModalComponents/EditWidgetModal/edit-widget-modal.component.html
+++ b/Gridly-Client/src/app/Components/ModalComponents/EditWidgetModal/edit-widget-modal.component.html
@@ -1,5 +1,5 @@
-<dialog #dlg modalWindow [open]="open" [modalId]="modalId" [id]="id" (openChange)="openChange.emit($event)" class="ew-dialog" (click)="modalDirective.onBackdropClick($event)">
-  <div class="ew-card" (click)="$event.stopPropagation()">
+<dialog #dlg appModalWindow [open]="open" [modalId]="modalId" [id]="id" (openChange)="openChange.emit($event)" class="ew-dialog">
+  <div class="ew-card">
     <header class="ew-header">
       <h3 id="ew-title" class="m-0">Edit {{modalId}}</h3>
       <button type="button" class="btn" aria-label="Close" (click)="close()">

--- a/Gridly-Client/src/app/Components/ModalComponents/EditWidgetModal/edit-widget-modal.component.ts
+++ b/Gridly-Client/src/app/Components/ModalComponents/EditWidgetModal/edit-widget-modal.component.ts
@@ -1,9 +1,8 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, AfterViewInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ModalDirective } from '../../../Directives/modal.directive';
 import { BaseModalComponent } from '../../../Directives/base-modal.component';
-import { ModalService } from '../../../Services/modal.service';
 import { ComponentModel } from '../../../Models/Component.Model';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
@@ -11,26 +10,26 @@ import { MatInputModule } from '@angular/material/input';
 import { EditWidgetModalFacade } from './edit-widget-modal.facade';
 
 @Component({
-  selector: 'edit-widget-modal',
+  selector: 'app-edit-widget-modal',
   imports: [CommonModule, FormsModule, ModalDirective, MatIconModule, MatSelectModule, MatInputModule],  
   templateUrl: './edit-widget-modal.component.html',
   styleUrls: ['../../../css/shared.modal.css', './edit-widget-modal.component.css'],
   providers: [EditWidgetModalFacade],
   standalone: true
 })
-export class EditWidgetModalComponent extends BaseModalComponent implements OnChanges {
-  @Input() open: boolean = false;
-  @Input() modalId: number = 0;
-  @Input() id: number = 0;
+export class EditWidgetModalComponent extends BaseModalComponent implements OnChanges, AfterViewInit {
+  @Input() open = false;
+  @Input() modalId = 0;
+  @Input() id = 0;
   @Input() component?: ComponentModel;
   @Output() openChange = new EventEmitter<number>();
   @Output() editedComponent = new EventEmitter();
   
   readonly facade: EditWidgetModalFacade;
 
-  constructor(modalService: ModalService, facade: EditWidgetModalFacade) {
-    super(modalService);
-    this.facade = facade;
+  constructor() {
+    super();
+    this.facade = inject(EditWidgetModalFacade);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -56,7 +55,7 @@ export class EditWidgetModalComponent extends BaseModalComponent implements OnCh
     }
   }
 
-  onSubmit() {
+  onSubmit(): void {
     const payload = this.facade.buildSubmitPayload(this.id);
     this.close();
     this.editedComponent.emit(payload);

--- a/Gridly-Client/src/app/Components/ModalComponents/EditWidgetModal/edit-widget-modal.facade.ts
+++ b/Gridly-Client/src/app/Components/ModalComponents/EditWidgetModal/edit-widget-modal.facade.ts
@@ -26,7 +26,7 @@ export class EditWidgetModalFacade {
 
   setIcon(event: string): void {
 
-    var iconData = new IconModel();
+    const iconData = new IconModel();
     iconData.materialIcon = event;
     iconData.type = "";
     iconData.name = "";
@@ -38,7 +38,7 @@ export class EditWidgetModalFacade {
   }
 
   reset(initial?: Partial<ComponentModel>): void {
-    //this.componentData = MapComponentData.Override(initial ?? {});
+    this.componentData = Object.assign(new ComponentModel(), initial ?? {});
   }
 
   buildSubmitPayload(widgetId: number): ComponentModel {

--- a/Gridly-Client/src/app/Components/ModalComponents/PromptModal/prompt-modal.component.html
+++ b/Gridly-Client/src/app/Components/ModalComponents/PromptModal/prompt-modal.component.html
@@ -1,5 +1,5 @@
-<dialog #dlg modalWindow [open]="open" [modalId]="modalId" [id]="id" (openChange)="openChange.emit($event)" class="ew-dialog" (click)="modalDirective?.onBackdropClick($event)">
-  <div class="ew-card" (click)="$event.stopPropagation()">
+<dialog #dlg appModalWindow [open]="open" [modalId]="modalId" [id]="id" (openChange)="openChange.emit($event)" class="ew-dialog">
+  <div class="ew-card">
     <header class="ew-header">
       <h3 id="ew-title" class="m-0">Edit {{modalId}}</h3>
       <button type="button" class="btn" aria-label="Close" (click)="close()">

--- a/Gridly-Client/src/app/Components/ModalComponents/PromptModal/prompt-modal.component.ts
+++ b/Gridly-Client/src/app/Components/ModalComponents/PromptModal/prompt-modal.component.ts
@@ -1,26 +1,21 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, AfterViewInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ModalDirective } from '../../../Directives/modal.directive';
 import { BaseModalComponent } from '../../../Directives/base-modal.component';
-import { ModalService } from '../../../Services/modal.service';
 
 @Component({
-  selector: 'prompt-modal',
+  selector: 'app-prompt-modal',
   templateUrl: './prompt-modal.component.html',
   styleUrls: ['../../../css/shared.modal.css'],
   standalone: true,
   imports: [FormsModule, ModalDirective],
 })
-export class PromptModalComponent extends BaseModalComponent implements OnChanges {
-  @Input() open: boolean = false;
-  @Input() modalId: number = 0;
-  @Input() id: number = 0;
+export class PromptModalComponent extends BaseModalComponent implements OnChanges, AfterViewInit {
+  @Input() open = false;
+  @Input() modalId = 0;
+  @Input() id = 0;
   @Output() openChange = new EventEmitter<number>();
   @Output() remove = new EventEmitter<{id: number}>();
-
-  constructor(modalService: ModalService) {
-    super(modalService);
-  }
 
   ngOnChanges(changes: SimpleChanges): void {
     setTimeout(() => {
@@ -51,8 +46,8 @@ export class PromptModalComponent extends BaseModalComponent implements OnChange
     }
   }
 
-    onSubmit() {
-      this.close();
-      this.remove.emit({id: this.id});
-    }
+  onSubmit(): void {
+    this.close();
+    this.remove.emit({ id: this.id });
+  }
 }

--- a/Gridly-Client/src/app/Constants/regex.strings.util.ts
+++ b/Gridly-Client/src/app/Constants/regex.strings.util.ts
@@ -1,5 +1,5 @@
 export class RegexStringsUtil {
   static readonly urlPattern = /^(https?:\/\/)?(www\.)?((([A-Za-z0-9-]+\.)+[A-Za-z]{2,})|((\d{1,3}\.){3}\d{1,3}))(:\d{1,5})?$/;
-  static readonly iconUrlPattern = /^(https?:\/\/(?:www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?::\d+)?(?:[\/?#][^\s]*)?)$|^(data:image\/(png|svg|jpeg|jpg|ico);base64,[A-Za-z0-9+/=]+)$/;
+  static readonly iconUrlPattern = /^(https?:\/\/(?:www\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?::\d+)?(?:[/?#][^\s]*)?)$|^(data:image\/(png|svg|jpeg|jpg|ico);base64,[A-Za-z0-9+/=]+)$/;
   static readonly namePattern = /^[A-Za-z]+$/;
 }

--- a/Gridly-Client/src/app/Directives/base-modal.component.ts
+++ b/Gridly-Client/src/app/Directives/base-modal.component.ts
@@ -1,4 +1,4 @@
-import { ViewChild, Directive } from '@angular/core';
+import { Directive, ViewChild, inject } from '@angular/core';
 import { ModalDirective } from './modal.directive';
 import { ModalService } from '../Services/modal.service';
 import { TextStringsUtil } from '../Constants/text.strings.util';
@@ -8,8 +8,7 @@ export abstract class BaseModalComponent {
   @ViewChild(ModalDirective) modalDirective!: ModalDirective;
 
   protected readonly TextStringsUtil = TextStringsUtil;
-
-  constructor(protected modalService: ModalService) {}
+  protected readonly modalService = inject(ModalService);
 
 
   close(): void {
@@ -26,7 +25,7 @@ export abstract class BaseModalComponent {
     this.close();
   }
 
-  onFileUpload(event: any) {
+  onFileUpload(event: Event): Promise<unknown> {
     return this.modalService.onFileUpload(event);
   }
 
@@ -38,4 +37,3 @@ export abstract class BaseModalComponent {
     return this.modalDirective?.open ?? false;
   }
 }
-

--- a/Gridly-Client/src/app/Directives/modal.directive.ts
+++ b/Gridly-Client/src/app/Directives/modal.directive.ts
@@ -1,27 +1,18 @@
-import {
-  AfterViewInit,
-  Directive,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, EventEmitter, HostListener, Input, OnChanges, Output, SimpleChanges, inject } from '@angular/core';
 
 @Directive({
-  selector: '[modalWindow]',
+  selector: '[appModalWindow]',
   standalone: true,
-  exportAs: 'modalWindow',
+  exportAs: 'appModalWindow',
 })
 export class ModalDirective implements AfterViewInit, OnChanges {
+  private el = inject<ElementRef<HTMLDialogElement>>(ElementRef);
 
-  @Input() modalId: number = 0;
-  @Input() id: number = 0;
-  @Input() open: boolean = false;
+
+  @Input() modalId = 0;
+  @Input() id = 0;
+  @Input() open = false;
   @Output() openChange = new EventEmitter<number>();
-
-  constructor(private el: ElementRef<HTMLDialogElement>) {}
 
   ngAfterViewInit(): void {
     this.syncDialog();
@@ -54,10 +45,11 @@ export class ModalDirective implements AfterViewInit, OnChanges {
     this.openChange.emit(this.modalId);
   }
 
-  save() {
+  save(): void {
     this.close();
   }
 
+  @HostListener('click', ['$event'])
   onBackdropClick(ev: MouseEvent): void {
     if (ev.target === this.el.nativeElement) {
       this.close();

--- a/Gridly-Client/src/app/Directives/resizable.directive.ts
+++ b/Gridly-Client/src/app/Directives/resizable.directive.ts
@@ -1,13 +1,15 @@
-import {Directive, ElementRef, HostListener, inject, Input, Renderer2} from '@angular/core';
-import {ComponentService} from "../Services/component.service";
-import { ComponentModel } from '../Models/Component.Model';
+import { Directive, ElementRef, HostListener, inject, Input, Renderer2 } from '@angular/core';
+import { ComponentService } from "../Services/component.service";
 
 @Directive({
   standalone: true,
-  selector: '[makeResizable]'
+  selector: '[appMakeResizable]'
 })
 
 export class ResizableDirective {
+  private el = inject(ElementRef);
+  private renderer = inject(Renderer2);
+
   @Input() canResize!: boolean;
   @Input() targetId!: number;
 
@@ -16,33 +18,30 @@ export class ResizableDirective {
   private component = this.#componentService.currentComponent();
   private components = this.#componentService.currentComponents();
 
-  private isResizing: boolean = false;
-  private startX: number = 0;
-  private startY: number = 0;
-  private startWidth: number = 0;
-  private startHeight: number = 0;
+  private isResizing = false;
+  private startX = 0;
+  private startY = 0;
+  private startWidth = 0;
+  private startHeight = 0;
   private gridItemElement: HTMLElement | null = null;
   private pointerId: number | null = null;
 
-  constructor(private el: ElementRef,
-              private renderer: Renderer2) {}
-
   @HostListener('pointerdown', ['$event'])
   OnPointerDown(event: PointerEvent): void {
-    if(!this.canResize || !this.targetId) return;
-    
+    if (!this.canResize || !this.targetId) return;
+
     event.preventDefault();
     event.stopPropagation();
-    
-    if(!this.component) return;
-    
+
+    if (!this.component) return;
+
     this.gridItemElement = this.el.nativeElement.closest('.grid-item-style') as HTMLElement;
-    
-    if(!this.gridItemElement) {
+
+    if (!this.gridItemElement) {
       let parent = this.el.nativeElement.parentElement;
       let depth = 0;
-      while(parent && depth < 10) {
-        if(parent.classList && parent.classList.contains('grid-item-style')) {
+      while (parent && depth < 10) {
+        if (parent.classList && parent.classList.contains('grid-item-style')) {
           this.gridItemElement = parent as HTMLElement;
           break;
         }
@@ -51,39 +50,39 @@ export class ResizableDirective {
       }
     }
     
-    if(!this.gridItemElement) {
+    if (!this.gridItemElement) {
       console.warn('Could not find grid-item-style element for component', this.targetId);
       return;
     }
-    
+
     try {
       this.el.nativeElement.setPointerCapture(event.pointerId);
       this.pointerId = event.pointerId;
-    } catch (e) {
-      console.warn('Failed to capture pointer:', e);
+    } catch {
+      console.warn('Failed to capture pointer.');
     }
-    
+
     this.startX = event.clientX;
     this.startY = event.clientY;
     this.startWidth = this.component.componentSettings?.width ?? 250;
-    this.startHeight = this.component . componentSettings?.height ?? 250;
+    this.startHeight = this.component.componentSettings?.height ?? 250;
     this.isResizing = true;
-    
+
     this.HideCursor();
   }
 
   @HostListener('document:pointermove', ['$event'])
   OnPointerMove(event: PointerEvent): void {
-    if(!this.isResizing || !this.gridItemElement || !this.component) return;
-    
-    if(this.pointerId !== null && event.pointerId !== this.pointerId) return;
-    
+    if (!this.isResizing || !this.gridItemElement || !this.component) return;
+
+    if (this.pointerId !== null && event.pointerId !== this.pointerId) return;
+
     const deltaX = event.clientX - this.startX;
     const deltaY = event.clientY - this.startY;
-    
+
     const newWidth = Math.max(250, this.startWidth + deltaX);
     const newHeight = Math.max(250, this.startHeight + deltaY);
-    
+
     const adjustedWidth = this.AdjustComponentSize(newWidth);
     const adjustedHeight = this.AdjustComponentSize(newHeight);
     
@@ -96,9 +95,9 @@ export class ResizableDirective {
 
     this.component = updatedComponent;
     
-    if(this.components) {
+    if (this.components) {
       const componentIndex = this.components.findIndex(c => c.id === this.targetId);
-      if(componentIndex !== -1) {
+      if (componentIndex !== -1) {
         this.components[componentIndex] = updatedComponent;
       }
     }
@@ -108,28 +107,30 @@ export class ResizableDirective {
     this.renderer.setStyle(this.gridItemElement, 'flex', '0 0 ' + adjustedWidth + 'px');
   }
 
-  @HostListener('document:pointerup', ['$event'])
-  OnPointerUp(event: PointerEvent): void {
-    if(!this.isResizing) return;
-    
-    if(this.pointerId !== null) {
+  @HostListener('document:pointerup')
+  OnPointerUp(): void {
+    if (!this.isResizing) return;
+
+    if (this.pointerId !== null) {
       try {
         this.el.nativeElement.releasePointerCapture(this.pointerId);
-      } catch (e) {
+      } catch {
+        // Ignore release errors when capture is already lost.
       }
       this.pointerId = null;
     }
     this.ResetAll();
   }
 
-  @HostListener('document:pointercancel', ['$event'])
-  OnPointerCancel(event: PointerEvent): void {
-    if(!this.isResizing) return;
-    
-    if(this.pointerId !== null) {
+  @HostListener('document:pointercancel')
+  OnPointerCancel(): void {
+    if (!this.isResizing) return;
+
+    if (this.pointerId !== null) {
       try {
         this.el.nativeElement.releasePointerCapture(this.pointerId);
-      } catch (e) {
+      } catch {
+        // Ignore release errors when capture is already lost.
       }
       this.pointerId = null;
     }
@@ -137,7 +138,7 @@ export class ResizableDirective {
   }
 
   private HideCursor(): void {
-    let body = document.body;
+    const body = document.body;
     this.renderer.setStyle(body, 'user-select', 'none');
     this.renderer.setStyle(body, '-webkit-user-select', 'none');
     this.renderer.setStyle(body, '-moz-user-select', 'none');
@@ -146,7 +147,7 @@ export class ResizableDirective {
   }
 
   private ShowCursor(): void {
-    let body = document.body;
+    const body = document.body;
     this.renderer.setStyle(body, 'user-select', 'auto');
     this.renderer.setStyle(body, '-webkit-user-select', 'auto');
     this.renderer.setStyle(body, '-moz-user-select', 'auto');
@@ -154,7 +155,7 @@ export class ResizableDirective {
     this.renderer.setStyle(body, 'cursor', 'auto');
   }
 
-  private ResetAll(){
+  private ResetAll(): void {
     this.isResizing = false;
     this.startX = 0;
     this.startY = 0;
@@ -165,19 +166,10 @@ export class ResizableDirective {
   }
 
   private AdjustComponentSize(value: number): number {
-    if(value < 250) return 250;
-    
-    switch(true){
-      case value > 300 && value <= 300:
-        return 300;
-      case value > 400 && value <= 600:
-        return 500;
-      case value > 600 && value <= 800:
-        return 700;
-      case value > 800:
-        return 800;
-      default:
-        return 250;
-    }
+    if (value <= 300) return 250;
+    if (value <= 500) return 300;
+    if (value <= 700) return 500;
+    if (value <= 800) return 700;
+    return 800;
   }
 }

--- a/Gridly-Client/src/app/Services/component.service.ts
+++ b/Gridly-Client/src/app/Services/component.service.ts
@@ -66,14 +66,16 @@ export class ComponentService{
       !item.componentSettings?.imageHidden;
   }
 
-    MaterialIconSet(item :ComponentModel): boolean {
+  MaterialIconSet(item :ComponentModel): boolean {
     return  item.iconData?.materialIcon !== undefined  &&
       item.iconData?.materialIcon !== "" &&
       !item.componentSettings?.imageHidden;
   }
 
+  readonly #componentHasBaseData = true;
+
   get ComponentHasBaseData(){
-    return true;
+    return this.#componentHasBaseData;
     /*
     return this.component.name !== undefined && "" &&
       this.component.url !== undefined && "" &&

--- a/Gridly-Client/src/app/Services/component.service.ts
+++ b/Gridly-Client/src/app/Services/component.service.ts
@@ -68,7 +68,7 @@ export class ComponentService{
       this.component.iconUrl !== undefined && "";*/
   }
 
-  get IconIsUrlHidden(){
+  /*get IconIsUrlHidden(){
     return this.iconUrlHidden;
   }
 
@@ -78,7 +78,7 @@ export class ComponentService{
 
   get ResizeModeActive(): boolean {
     return this.editMode;
-  }
+  }*/
 
   CheckComponentData(item:ComponentModel): boolean {
     return item !== undefined &&

--- a/Gridly-Client/src/app/Services/endpoints/component.endpoint.service.ts
+++ b/Gridly-Client/src/app/Services/endpoints/component.endpoint.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {UrlStringsUtil} from "../../Constants/url.strings.util";
 import {ComponentModel} from "../../Models/Component.Model";
 import {Observable, take} from "rxjs";
@@ -10,8 +10,8 @@ import { EditComponentModel } from '../../Models/editComponent.Model';
 })
 
 export class ComponentEndpointService{
+  private http = inject(HttpClient);
 
-  constructor(private http: HttpClient) {}
 
   delete(id: number) {
     return this.http.delete<ComponentModel>(UrlStringsUtil.ComponentUrlDelete+id).pipe(take(1));

--- a/Gridly-Client/src/app/Services/endpoints/icon.endpoint.service.ts
+++ b/Gridly-Client/src/app/Services/endpoints/icon.endpoint.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from "@angular/common/http";
 import { IconModel } from '../../Models/Icon.Model';
 import { Observable } from 'rxjs/internal/Observable';
@@ -10,7 +10,8 @@ import { SearchIconsResultDto } from '../../DTOs/SearchIconsResultDto';
   providedIn: 'root'
 })
 export class IconEndpointService{
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+
 
   get(): Observable<IconModel> {
     return this.http.get<IconModel>(UrlStringsUtil.IconGet).pipe(take(1));

--- a/Gridly-Client/src/app/Services/endpoints/version.endpoint.service.ts
+++ b/Gridly-Client/src/app/Services/endpoints/version.endpoint.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {VersionModel} from "../../Models/Version.Model";
 import {UrlStringsUtil} from "../../Constants/url.strings.util";
@@ -9,7 +9,8 @@ import {Observable, take} from "rxjs";
 })
 
 export class VersionEndpointService{
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+
 
   get(): Observable<VersionModel> {
     return this.http.get<VersionModel>(UrlStringsUtil.GetVersionUrl).pipe(take(1));

--- a/Gridly-Client/src/app/Services/modal.service.ts
+++ b/Gridly-Client/src/app/Services/modal.service.ts
@@ -9,7 +9,7 @@ import { ImageExtensionsType } from '../Types/image.extensions.type.enum';
 export class ModalService {
   readonly resetFile$ = new Subject<void>();
   #componentService = inject(ComponentService);
-  readonly #supportedImageExtensions: ReadonlyArray<string> = [
+  readonly #supportedImageExtensions: readonly string[] = [
     ImageExtensionsType.Svg,
     ImageExtensionsType.Png,
     ImageExtensionsType.Jpg,

--- a/Gridly-Client/src/app/app.component.html
+++ b/Gridly-Client/src/app/app.component.html
@@ -1,3 +1,3 @@
 
-<header-component></header-component>
-<grid-component></grid-component>
+<app-header></app-header>
+<app-grid></app-grid>


### PR DESCRIPTION
## Summary
- add `angular-eslint` with flat config and an Angular `lint` target
- enforce zero warnings through `maxWarnings: 0` and a `lint` npm script
- clean the current Angular codebase so the new lint rules pass without warnings

## Verification
- `npm run lint`
- `npx tsc -p tsconfig.app.json --noEmit`

## Notes
- `npx ng build` exited abruptly in the local environment under Node.js `v25.9.0`, so I used the TypeScript compile check as the reliable verification step here

Closes #243