### PR TITLE
Add Angular eslint check with zero warnings

### DIFF
--- a/.github/workflows/Build_Test_Branches.yml
+++ b/.github/workflows/Build_Test_Branches.yml
@@ -42,6 +42,10 @@ jobs:
         run: npm run build
         working-directory:  ${{ env.ANGULAR_PATH }}
 
+      - name: Run eslint
+        run: npm run lint -- --maxWarnings=0
+        working-directory: ${{ env.ANGULAR_PATH }}
+
       # No Jest or karma-jasmine libraries, so skipping Angular tests for now
       #- name: Test Angular
       #  run: npm run test -- --watch=false --browsers=ChromeHeadless

--- a/.github/workflows/Build_Test_Branches.yml
+++ b/.github/workflows/Build_Test_Branches.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory:  ${{ env.ANGULAR_PATH }}
 
       - name: Run eslint
-        run: npm run lint -- --maxWarnings=0
+        run: npm run lint -- --max-warnings=0
         working-directory: ${{ env.ANGULAR_PATH }}
 
       # No Jest or karma-jasmine libraries, so skipping Angular tests for now


### PR DESCRIPTION
Adds a `Run eslint` step to `.github/workflows/Build_Test_Branches.yml` directly after the Angular build step.

Changes:
- runs `npm run lint -- --maxWarnings=0`
- uses `working-directory: ${{ env.ANGULAR_PATH }}`
- keeps the change scoped to the workflow file only