### PR TITLE
Add xUnit tests for the .NET app

### DIFF
--- a/.github/workflows/Build_Test_Branches.yml
+++ b/.github/workflows/Build_Test_Branches.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Install Angular dependencies
         run: npm install

--- a/Gridly.csproj
+++ b/Gridly.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,12 +42,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="dapper" Version="2.1.66" />
     <PackageReference Include="dapper.sqlbuilder" Version="2.1.66" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.1.25080.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/Tests/AssemblyInfo.cs
+++ b/Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Tests/Factories/ComponentFactoryTests.cs
+++ b/Tests/Factories/ComponentFactoryTests.cs
@@ -1,0 +1,46 @@
+using Gridly.Dtos;
+using Gridly.Factories;
+
+namespace Gridly.Tests.Factories;
+
+public class ComponentFactoryTests
+{
+    [Fact]
+    public void Create_MapsDtoFieldsToComponentModel()
+    {
+        var dto = new ComponentDtoModel
+        {
+            ComponentId = 12,
+            IndexPosition = 3,
+            ComponentName = "Docs",
+            Url = "https://example.test",
+            IconUrl = "/icons/docs.svg"
+        };
+
+        var result = ComponentFactory.Create(dto);
+
+        Assert.Equal(dto.ComponentId, result.Id);
+        Assert.Equal(dto.IndexPosition, result.IndexPosition);
+        Assert.Equal(dto.ComponentName, result.Name);
+        Assert.Equal(dto.Url, result.Url);
+        Assert.Equal(dto.IconUrl, result.IconUrl);
+    }
+
+    [Fact]
+    public void CreateMany_PreservesOrderAndCount()
+    {
+        var dtos = new[]
+        {
+            new ComponentDtoModel { ComponentId = 1, ComponentName = "First" },
+            new ComponentDtoModel { ComponentId = 2, ComponentName = "Second" }
+        };
+
+        var result = ComponentFactory.CreateMany(dtos).ToArray();
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal("First", result[0].Name);
+        Assert.Equal(2, result[1].Id);
+        Assert.Equal("Second", result[1].Name);
+    }
+}

--- a/Tests/Factories/IconFactoryTests.cs
+++ b/Tests/Factories/IconFactoryTests.cs
@@ -1,0 +1,53 @@
+using Gridly.Factories;
+using Gridly.Models;
+
+namespace Gridly.Tests.Factories;
+
+public class IconFactoryTests
+{
+    [Fact]
+    public void Create_WithNullInput_ReturnsDefaultIcon()
+    {
+        var result = IconFactory.Create(null);
+
+        Assert.Equal(string.Empty, result.Name);
+        Assert.Equal(string.Empty, result.Type);
+        Assert.Equal(string.Empty, result.Base64Data);
+        Assert.Equal("add_box e146", result.MaterialIcon);
+    }
+
+    [Fact]
+    public void Create_WithValues_PreservesProvidedValues()
+    {
+        var icon = new IconModel
+        {
+            Name = "grid",
+            Type = "svg",
+            Base64Data = "Zm9v",
+            MaterialIcon = "dashboard"
+        };
+
+        var result = IconFactory.Create(icon);
+
+        Assert.Equal(icon.Name, result.Name);
+        Assert.Equal(icon.Type, result.Type);
+        Assert.Equal(icon.Base64Data, result.Base64Data);
+        Assert.Equal(icon.MaterialIcon, result.MaterialIcon);
+    }
+
+    [Fact]
+    public void Create_WithNullMaterialIcon_FallsBackToDefault()
+    {
+        var icon = new IconModel
+        {
+            Name = "grid",
+            Type = "svg",
+            Base64Data = "Zm9v",
+            MaterialIcon = null!
+        };
+
+        var result = IconFactory.Create(icon);
+
+        Assert.Equal("add_box e146", result.MaterialIcon);
+    }
+}

--- a/Tests/Handlers/IconHandlerTests.cs
+++ b/Tests/Handlers/IconHandlerTests.cs
@@ -1,0 +1,77 @@
+using Gridly.Command;
+using Gridly.Constants;
+using Gridly.Dtos;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.Handlers;
+
+using SearchIconsHandler = global::ComponentHandler;
+
+public class IconHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenCacheHasIcons_FiltersWithoutCallingHttp()
+    {
+        var cache = new FakeMemoryCashingService();
+        cache.Seed("mat-icons", new[] { "home e001", "grid_view e002", "search e003" });
+        var httpClient = new FakeHttpClientServices();
+        var handler = new SearchIconsHandler(httpClient, cache);
+
+        var result = await handler.Handle(new SearchIconsCommand { Value = "GRID" }, CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<SearchIconsResultDto>(result);
+
+        Assert.Single(payload.Icons);
+        Assert.Equal("grid_view e002", payload.Icons[0]);
+        Assert.Equal(0, httpClient.CallCount);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCacheMisses_FetchesStoresAndReturnsMatches()
+    {
+        var cache = new FakeMemoryCashingService();
+        var httpClient = new FakeHttpClientServices
+        {
+            Response = (true, "home e001\ngrid_view e002\nsearch e003")
+        };
+        var handler = new SearchIconsHandler(httpClient, cache);
+
+        var result = await handler.Handle(new SearchIconsCommand { Value = "e00" }, CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<SearchIconsResultDto>(result);
+
+        Assert.Equal(3, payload.Icons.Length);
+        Assert.Equal(1, httpClient.CallCount);
+        Assert.Equal(EndpointStrings.materialIconsEndPoint, httpClient.LastUrl);
+        Assert.Equal(1, cache.StoreCallCount);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRemotePayloadIsEmpty_ReturnsNoContent()
+    {
+        var cache = new FakeMemoryCashingService();
+        var httpClient = new FakeHttpClientServices { Response = (true, string.Empty) };
+        var handler = new SearchIconsHandler(httpClient, cache);
+
+        var result = await handler.Handle(new SearchIconsCommand { Value = "grid" }, CancellationToken.None);
+
+        ResultAssertions.AssertStatusCode(result, StatusCodes.Status204NoContent);
+        Assert.Equal(1, httpClient.CallCount);
+        Assert.Equal(0, cache.StoreCallCount);
+    }
+
+    [Fact]
+    public async Task Handle_LimitsResultsToFiftyMatches()
+    {
+        var icons = Enumerable.Range(1, 60).Select(i => $"grid_{i:00} e{i:000}").ToArray();
+        var cache = new FakeMemoryCashingService();
+        cache.Seed("mat-icons", icons);
+        var httpClient = new FakeHttpClientServices();
+        var handler = new SearchIconsHandler(httpClient, cache);
+
+        var result = await handler.Handle(new SearchIconsCommand { Value = "grid_" }, CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<SearchIconsResultDto>(result);
+
+        Assert.Equal(50, payload.Icons.Length);
+        Assert.Equal("grid_01 e001", payload.Icons[0]);
+        Assert.Equal("grid_50 e050", payload.Icons[49]);
+    }
+}

--- a/Tests/Handlers/VersionHandlerTests.cs
+++ b/Tests/Handlers/VersionHandlerTests.cs
@@ -1,0 +1,87 @@
+using Gridly.Command;
+using Gridly.Handlers;
+using Gridly.Models;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.Handlers;
+
+public class VersionHandlerTests
+{
+    [Fact]
+    public async Task HandleGetVersion_WhenCached_ReturnsCachedVersionWithoutCallingEndpoint()
+    {
+        var cache = new FakeMemoryCashingService();
+        var cachedVersion = new VersionModel { Name = "1.0.0", NewRelease = false };
+        cache.Seed("version", cachedVersion);
+        var endPoint = new FakeVersionEndPoint();
+        var handler = new VersionHandler(endPoint, cache);
+
+        var result = await handler.Handle(new GetVersionCommand(), CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<VersionModel>(result);
+
+        Assert.Equal(cachedVersion.Name, payload.Name);
+        Assert.Equal(0, endPoint.GetVersionCallCount);
+    }
+
+    [Fact]
+    public async Task HandleGetVersion_WhenRemoteFetchSucceeds_StoresAndReturnsVersion()
+    {
+        var version = new VersionModel { Name = "2.0.0", NewRelease = true };
+        var endPoint = new FakeVersionEndPoint { GetVersionResult = (true, version) };
+        var cache = new FakeMemoryCashingService();
+        var handler = new VersionHandler(endPoint, cache);
+
+        var result = await handler.Handle(new GetVersionCommand(), CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<VersionModel>(result);
+
+        Assert.Equal(version.Name, payload.Name);
+        Assert.Equal(1, endPoint.GetVersionCallCount);
+        Assert.Equal(1, cache.StoreCallCount);
+        Assert.Equal("version", cache.LastStoredKey);
+        Assert.Same(version, cache.LastStoredValue);
+    }
+
+    [Fact]
+    public async Task HandleGetVersion_WhenRemoteFetchFails_ReturnsNotFound()
+    {
+        var endPoint = new FakeVersionEndPoint { GetVersionResult = (false, null) };
+        var cache = new FakeMemoryCashingService();
+        var handler = new VersionHandler(endPoint, cache);
+
+        var result = await handler.Handle(new GetVersionCommand(), CancellationToken.None);
+
+        ResultAssertions.AssertStatusCode(result, StatusCodes.Status404NotFound);
+        Assert.Equal(1, endPoint.GetVersionCallCount);
+        Assert.Equal(0, cache.StoreCallCount);
+    }
+
+    [Fact]
+    public async Task HandleGetLatestVersion_WhenRemoteFetchSucceeds_StoresAndReturnsVersion()
+    {
+        var version = new VersionModel { Name = "3.0.0", NewRelease = true };
+        var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (true, version) };
+        var cache = new FakeMemoryCashingService();
+        var handler = new VersionHandler(endPoint, cache);
+
+        var result = await handler.Handle(new GetLatestVersionCommand(), CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<VersionModel>(result);
+
+        Assert.Equal(version.Name, payload.Name);
+        Assert.Equal(1, endPoint.GetLatestVersionCallCount);
+        Assert.Equal(1, cache.StoreCallCount);
+    }
+
+    [Fact]
+    public async Task HandleGetLatestVersion_WhenRemoteFetchFails_ReturnsNotFound()
+    {
+        var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (false, null) };
+        var cache = new FakeMemoryCashingService();
+        var handler = new VersionHandler(endPoint, cache);
+
+        var result = await handler.Handle(new GetLatestVersionCommand(), CancellationToken.None);
+
+        ResultAssertions.AssertStatusCode(result, StatusCodes.Status404NotFound);
+        Assert.Equal(1, endPoint.GetLatestVersionCallCount);
+        Assert.Equal(0, cache.StoreCallCount);
+    }
+}

--- a/Tests/Helpers/ComponentHandlerHelperTests.cs
+++ b/Tests/Helpers/ComponentHandlerHelperTests.cs
@@ -1,0 +1,95 @@
+using Gridly.helpers;
+using Gridly.Models;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.Helpers;
+
+public class ComponentHandlerHelperTests
+{
+    [Fact]
+    public void IconDataHasValue_ReturnsTrue_WhenAllFieldsExist()
+    {
+        var helper = new ComponentHandlerHelper(new FakeFileService());
+        var icon = new IconModel { Name = "grid", Type = "svg", Base64Data = "Zm9v" };
+
+        var result = helper.IconDataHasValue(icon);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IconDataHasValue_ReturnsFalse_WhenIconIsNull()
+    {
+        var helper = new ComponentHandlerHelper(new FakeFileService());
+
+        var result = helper.IconDataHasValue(null!);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(null, "svg", "Zm9v")]
+    [InlineData("grid", null, "Zm9v")]
+    [InlineData("grid", "svg", null)]
+    [InlineData("", "svg", "Zm9v")]
+    public void IconDataHasValue_ReturnsFalse_WhenAnyRequiredFieldIsMissing(
+        string? name,
+        string? type,
+        string? base64Data)
+    {
+        var helper = new ComponentHandlerHelper(new FakeFileService());
+        var icon = new IconModel
+        {
+            Name = name!,
+            Type = type!,
+            Base64Data = base64Data!
+        };
+
+        var result = helper.IconDataHasValue(icon);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void UploadIcon_DelegatesToFileService()
+    {
+        var fileService = new FakeFileService { UploadIconResult = true };
+        var helper = new ComponentHandlerHelper(fileService);
+        var component = new ComponentModel { IconData = new IconModel { Name = "grid", Type = "svg", Base64Data = "Zm9v" } };
+
+        var result = helper.UploadIcon(component);
+
+        Assert.True(result);
+        Assert.Same(component.IconData, fileService.UploadedIcon);
+    }
+
+    [Fact]
+    public void DeleteIcon_DelegatesToFileService()
+    {
+        var fileService = new FakeFileService { DeleteIconResult = true };
+        var helper = new ComponentHandlerHelper(fileService);
+        var component = new ComponentModel { IconData = new IconModel { Name = "grid", Type = "svg" } };
+
+        var result = helper.DeleteIcon(component);
+
+        Assert.True(result);
+        Assert.Equal(("grid", "svg"), fileService.DeletedIcon);
+    }
+
+    [Fact]
+    public void SetIndexValues_ReassignsSequentialOneBasedIndexes()
+    {
+        var helper = new ComponentHandlerHelper(new FakeFileService());
+        var components = new List<ComponentModel>
+        {
+            new() { Id = 11, IndexPosition = 99 },
+            new() { Id = 17, IndexPosition = 42 },
+            new() { Id = 23, IndexPosition = null }
+        };
+
+        var result = helper.SetIndexValues(components).ToArray();
+
+        Assert.Equal(new int?[] { 1, 2, 3 }, result.Select(x => x.IndexPosition).ToArray());
+        Assert.Equal(new[] { 11, 17, 23 }, result.Select(x => x.Id).ToArray());
+    }
+}

--- a/Tests/Infrastructure/ResultAssertions.cs
+++ b/Tests/Infrastructure/ResultAssertions.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Gridly.Tests.Infrastructure;
+
+internal static class ResultAssertions
+{
+    public static T AssertOk<T>(IResult result)
+    {
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        Assert.Equal(StatusCodes.Status200OK, statusResult.StatusCode);
+
+        var valueResult = Assert.IsAssignableFrom<IValueHttpResult>(result);
+        return Assert.IsType<T>(valueResult.Value);
+    }
+
+    public static void AssertStatusCode(IResult result, int expectedStatusCode)
+    {
+        var statusResult = Assert.IsAssignableFrom<IStatusCodeHttpResult>(result);
+        Assert.Equal(expectedStatusCode, statusResult.StatusCode);
+    }
+}

--- a/Tests/Infrastructure/TestDoubles.cs
+++ b/Tests/Infrastructure/TestDoubles.cs
@@ -1,0 +1,97 @@
+using Gridly.EndPoints;
+using Gridly.Models;
+using Gridly.Services;
+
+namespace Gridly.Tests.Infrastructure;
+
+internal sealed class FakeFileService : IFileService
+{
+    public bool UploadIconResult { get; set; } = true;
+    public bool DeleteIconResult { get; set; } = true;
+    public IconModel? UploadedIcon { get; private set; }
+    public (string Name, string Type)? DeletedIcon { get; private set; }
+    public IEnumerable<FileInfo> Icons { get; set; } = Array.Empty<FileInfo>();
+
+    public bool FileExist(string filePath) => File.Exists(filePath);
+    public bool DeletedFile(string filePath) => true;
+    public bool WriteAllBitesToFile(string filePath, string content) => true;
+    public bool WriteToFile(string filePath, string content) => true;
+    public Task<string> ReadAllFromFileAsync(string filePath) => Task.FromResult(string.Empty);
+    public IEnumerable<FileInfo> GetAllIcons() => Icons;
+
+    public bool UploadIcon(IconModel iconData)
+    {
+        UploadedIcon = iconData;
+        return UploadIconResult;
+    }
+
+    public bool DeleteIcon(string name, string type)
+    {
+        DeletedIcon = (name, type);
+        return DeleteIconResult;
+    }
+}
+
+internal sealed class FakeMemoryCashingService : IMemoryCashingService
+{
+    private readonly Dictionary<string, object> _cache = new();
+
+    public int GetCallCount { get; private set; }
+    public int StoreCallCount { get; private set; }
+    public string? LastStoredKey { get; private set; }
+    public object? LastStoredValue { get; private set; }
+
+    public T? Get<T>(string key) where T : class
+    {
+        GetCallCount++;
+        return _cache.TryGetValue(key, out var value) ? value as T : null;
+    }
+
+    public bool Store<T>(string key, T item) where T : class
+    {
+        StoreCallCount++;
+        LastStoredKey = key;
+        LastStoredValue = item;
+        _cache[key] = item;
+        return true;
+    }
+
+    public void Seed<T>(string key, T item) where T : class
+    {
+        _cache[key] = item;
+    }
+}
+
+internal sealed class FakeVersionEndPoint : IVersionEndPoint
+{
+    public int GetVersionCallCount { get; private set; }
+    public int GetLatestVersionCallCount { get; private set; }
+    public (bool Success, VersionModel? Version) GetVersionResult { get; set; }
+    public (bool Success, VersionModel? Version) GetLatestVersionResult { get; set; }
+
+    public Task<(bool, VersionModel?)> GetLatestVersion()
+    {
+        GetLatestVersionCallCount++;
+        return Task.FromResult((GetLatestVersionResult.Success, GetLatestVersionResult.Version));
+    }
+
+    public Task<(bool, VersionModel?)> GetVersion()
+    {
+        GetVersionCallCount++;
+        return Task.FromResult((GetVersionResult.Success, GetVersionResult.Version));
+    }
+}
+
+internal sealed class FakeHttpClientServices : IHttpClientServices
+{
+    public int CallCount { get; private set; }
+    public string? LastUrl { get; private set; }
+    public (bool Success, string Response) Response { get; set; }
+
+    public Task<(bool, string)> Get(string url)
+    {
+        CallCount++;
+        LastUrl = url;
+        return Task.FromResult((Response.Success, Response.Response));
+    }
+}

--- a/Tests/Repositories/IconRepositoryTests.cs
+++ b/Tests/Repositories/IconRepositoryTests.cs
@@ -1,0 +1,83 @@
+using Gridly.Models;
+using Gridly.Repositories;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.Repositories;
+
+public sealed class IconRepositoryTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), $"gridly-icons-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void FindUnusedIcons_ReturnsOnlyFilesNotReferencedByComponents()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var usedIcon = CreateFile("used.svg");
+        var unusedIcon = CreateFile("unused.png");
+        var fileService = new FakeFileService
+        {
+            Icons = new[] { new FileInfo(usedIcon), new FileInfo(unusedIcon) }
+        };
+        var repository = new IconRepository(null!, fileService);
+        var components = new[]
+        {
+            new ComponentModel
+            {
+                IconData = new IconModel { Name = "used", Type = "svg" }
+            }
+        };
+
+        var result = repository.FindUnusedIcons(components);
+
+        Assert.Single(result);
+        Assert.Equal("unused.png", result[0]);
+    }
+
+    [Fact]
+    public void FindUnusedIcons_WhenAllIconsAreUsed_ReturnsEmptyList()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var usedIcon = CreateFile("used.svg");
+        var fileService = new FakeFileService
+        {
+            Icons = new[] { new FileInfo(usedIcon) }
+        };
+        var repository = new IconRepository(null!, fileService);
+        var components = new[]
+        {
+            new ComponentModel
+            {
+                IconData = new IconModel { Name = "used", Type = "svg" }
+            }
+        };
+
+        var result = repository.FindUnusedIcons(components);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FindUnusedIcons_WhenThereAreNoFiles_ReturnsEmptyList()
+    {
+        var repository = new IconRepository(null!, new FakeFileService());
+
+        var result = repository.FindUnusedIcons(Array.Empty<ComponentModel>());
+
+        Assert.Empty(result);
+    }
+
+    private string CreateFile(string fileName)
+    {
+        var filePath = Path.Combine(_tempDirectory, fileName);
+        File.WriteAllText(filePath, fileName);
+        return filePath;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+}

--- a/Tests/Services/DataConverterTests.cs
+++ b/Tests/Services/DataConverterTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Gridly.Models;
+using Gridly.Services;
+
+namespace Gridly.Tests.Services;
+
+public class DataConverterTests
+{
+    private readonly DataConverter<VersionModel> _converter = new();
+
+    [Fact]
+    public void DeserializeJson_ReturnsObject()
+    {
+        const string json = """{"name":"1.2.3","newRelease":true}""";
+
+        var result = _converter.DeserializeJson(json);
+
+        Assert.NotNull(result);
+        Assert.Equal("1.2.3", result.Name);
+        Assert.True(result.NewRelease);
+    }
+
+    [Fact]
+    public void DeserializeJsonToArray_ReturnsArray()
+    {
+        const string json = """[{"name":"1.0.0","newRelease":false},{"name":"1.1.0","newRelease":true}]""";
+
+        var result = _converter.DeserializeJsonToArray(json);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("1.1.0", result[1].Name);
+    }
+
+    [Fact]
+    public void DeserializeJson_InvalidPayload_ThrowsJsonException()
+    {
+        Assert.Throws<JsonException>(() => _converter.DeserializeJson("{"));
+    }
+
+    [Fact]
+    public void SerializerToJsonString_ForObject_SerializesProperties()
+    {
+        var model = new VersionModel { Name = "2.0.0", NewRelease = true };
+
+        var result = _converter.SerializerToJsonString(model);
+
+        Assert.Equal("""{"name":"2.0.0","newRelease":true}""", result);
+    }
+
+    [Fact]
+    public void SerializerToJsonString_ForEnumerable_SerializesCollection()
+    {
+        var models = new[]
+        {
+            new VersionModel { Name = "1.0.0", NewRelease = false },
+            new VersionModel { Name = "2.0.0", NewRelease = true }
+        };
+
+        var result = _converter.SerializerToJsonString(models);
+
+        Assert.Equal("""[{"name":"1.0.0","newRelease":false},{"name":"2.0.0","newRelease":true}]""", result);
+    }
+
+    [Fact]
+    public void ToInt_StripsNonDigitCharacters()
+    {
+        var result = _converter.ToInt("v1.2.3");
+
+        Assert.Equal(123, result);
+    }
+
+    [Fact]
+    public void ToInt_WithoutDigits_ThrowsFormatException()
+    {
+        Assert.Throws<FormatException>(() => _converter.ToInt("version"));
+    }
+}

--- a/Tests/Services/FileServiceTests.cs
+++ b/Tests/Services/FileServiceTests.cs
@@ -1,0 +1,134 @@
+using Gridly.Models;
+using Gridly.Services;
+
+namespace Gridly.Tests.Services;
+
+public sealed class FileServiceTests : IDisposable
+{
+    private readonly FileService _service = new();
+    private readonly string _iconDirectory = Path.Combine(Directory.GetCurrentDirectory(), "Assets", "Icons");
+    private readonly List<string> _createdFiles = new();
+
+    [Fact]
+    public async Task WriteToFile_WritesExpectedText()
+    {
+        var filePath = CreateUniquePath(".txt");
+
+        var result = _service.WriteToFile(filePath, "hello world");
+
+        Assert.True(result);
+        Assert.Equal("hello world", await File.ReadAllTextAsync(filePath));
+    }
+
+    [Fact]
+    public void WriteAllBitesToFile_WritesDecodedBytes()
+    {
+        var filePath = CreateUniquePath(".bin");
+        var base64 = Convert.ToBase64String([1, 2, 3, 4]);
+
+        var result = _service.WriteAllBitesToFile(filePath, base64);
+
+        Assert.True(result);
+        Assert.Equal(new byte[] { 1, 2, 3, 4 }, File.ReadAllBytes(filePath));
+    }
+
+    [Fact]
+    public void DeletedFile_RemovesExistingFile()
+    {
+        var filePath = CreateUniquePath(".txt");
+        File.WriteAllText(filePath, "content");
+
+        var result = _service.DeletedFile(filePath);
+
+        Assert.True(result);
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void UploadIcon_CreatesFileInIconDirectory()
+    {
+        EnsureIconDirectory();
+        var fileName = $"upload-{Guid.NewGuid():N}";
+        var icon = new IconModel
+        {
+            Name = fileName,
+            Type = "png",
+            Base64Data = Convert.ToBase64String([5, 6, 7])
+        };
+
+        var result = _service.UploadIcon(icon);
+        var filePath = Path.Combine(_iconDirectory, $"{fileName}.png");
+        _createdFiles.Add(filePath);
+
+        Assert.True(result);
+        Assert.True(File.Exists(filePath));
+        Assert.Equal(new byte[] { 5, 6, 7 }, File.ReadAllBytes(filePath));
+    }
+
+    [Fact]
+    public void DeleteIcon_RemovesFileFromIconDirectory()
+    {
+        EnsureIconDirectory();
+        var fileName = $"delete-{Guid.NewGuid():N}";
+        var filePath = Path.Combine(_iconDirectory, $"{fileName}.svg");
+        File.WriteAllText(filePath, "svg");
+
+        var result = _service.DeleteIcon(fileName, "svg");
+
+        Assert.True(result);
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public void GetAllIcons_ReturnsAllowedFilesAndExcludesFavicon()
+    {
+        EnsureIconDirectory();
+        var includedPath = Path.Combine(_iconDirectory, $"keep-{Guid.NewGuid():N}.png");
+        var excludedPath = Path.Combine(_iconDirectory, $"skip-{Guid.NewGuid():N}.txt");
+        var faviconPath = Path.Combine(_iconDirectory, "favicon.ico");
+
+        File.WriteAllText(includedPath, "png");
+        File.WriteAllText(excludedPath, "txt");
+        var restoreFavicon = !File.Exists(faviconPath);
+        if (restoreFavicon)
+        {
+            File.WriteAllText(faviconPath, "ico");
+        }
+
+        _createdFiles.Add(includedPath);
+        _createdFiles.Add(excludedPath);
+        if (restoreFavicon)
+        {
+            _createdFiles.Add(faviconPath);
+        }
+
+        var result = _service.GetAllIcons().Select(file => file.Name).ToArray();
+
+        Assert.Contains(Path.GetFileName(includedPath), result);
+        Assert.DoesNotContain(Path.GetFileName(excludedPath), result);
+        Assert.DoesNotContain("favicon.ico", result);
+    }
+
+    private string CreateUniquePath(string extension)
+    {
+        var filePath = Path.Combine(Path.GetTempPath(), $"gridly-{Guid.NewGuid():N}{extension}");
+        _createdFiles.Add(filePath);
+        return filePath;
+    }
+
+    private void EnsureIconDirectory()
+    {
+        Directory.CreateDirectory(_iconDirectory);
+    }
+
+    public void Dispose()
+    {
+        foreach (var filePath in _createdFiles)
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+}

--- a/Tests/Services/MemoryCashingServicesTests.cs
+++ b/Tests/Services/MemoryCashingServicesTests.cs
@@ -1,0 +1,32 @@
+using Gridly.Services;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Gridly.Tests.Services;
+
+public class MemoryCashingServicesTests
+{
+    [Fact]
+    public void Store_ThenGet_ReturnsStoredInstance()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var service = new MemoryCashingServices(memoryCache);
+        var version = "1.2.3";
+
+        var stored = service.Store("version", version);
+        var cached = service.Get<string>("version");
+
+        Assert.True(stored);
+        Assert.Equal(version, cached);
+    }
+
+    [Fact]
+    public void Get_MissingKey_ReturnsNull()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var service = new MemoryCashingServices(memoryCache);
+
+        var cached = service.Get<string>("missing");
+
+        Assert.Null(cached);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test support directly in the `Gridly` .NET project
- add backend-only tests under `Tests/` without touching `Gridly-Client`
- cover factories, helpers, services, icon search, version handling, and unused icon detection

## Verification
- `dotnet test Gridly.csproj --no-build -v minimal`
- 41 tests passed

Closes #242