### PR TITLE
Fix add-card save reloading the page before the save completes

### DIFF
--- a/Gridly-Client/src/app/components/header/header.component.spec.ts
+++ b/Gridly-Client/src/app/components/header/header.component.spec.ts
@@ -25,11 +25,12 @@ describe('HeaderComponent', () => {
     toggleEdit: jest.fn(() => editMode.update((value) => !value)),
     setEditMode: jest.fn((value: boolean) => editMode.set(value)),
     addCardToFirstAvailableRow: jest.fn(),
-    batchSave: jest.fn(),
+    batchSave: jest.fn(() => Promise.resolve()),
     currentRowColumns: jest.fn(() => []),
   };
 
   beforeEach(async () => {
+    editMode.set(false);
     gridServiceMock.toggleEdit.mockClear();
     gridServiceMock.setEditMode.mockClear();
     gridServiceMock.addCardToFirstAvailableRow.mockClear();
@@ -60,6 +61,17 @@ describe('HeaderComponent', () => {
 
     expect(gridServiceMock.toggleEdit).toHaveBeenCalledTimes(2);
     expect(headerComponent.editActive()).toBe(false); 
+  });
+
+  it('waits for the save to complete before exiting edit mode and reloading', async () => {
+    await headerComponent.save();
+
+    expect(gridServiceMock.batchSave).toHaveBeenCalledTimes(1);
+    expect(gridServiceMock.toggleEdit).toHaveBeenCalledTimes(1);
+
+    const batchSaveOrder = gridServiceMock.batchSave.mock.invocationCallOrder[0];
+    const toggleEditOrder = gridServiceMock.toggleEdit.mock.invocationCallOrder[0];
+    expect(batchSaveOrder).toBeLessThan(toggleEditOrder);
   });
 
   it('adds cards to the current grid rows and closes the dialog', () => {

--- a/Gridly-Client/src/app/components/header/header.component.ts
+++ b/Gridly-Client/src/app/components/header/header.component.ts
@@ -36,9 +36,9 @@ export class HeaderComponent {
     }
   }
 
-  save(): void {
+  async save(): Promise<void> {
+    await this.#gridService.batchSave(this.#gridService.currentRowColumns());
     this.toggleMenu();
-    this.#gridService.batchSave(this.#gridService.currentRowColumns());
   }
 
   protected reloadPage(): void {


### PR DESCRIPTION
## Summary
- `HeaderComponent.save()` called `toggleMenu()` (which triggers `location.reload()` on exiting edit mode) *before* `GridService.batchSave()`'s async POST had a chance to complete, so the reload frequently raced ahead of (and could abort) the save of newly added card(s). Most visible on the first card, since an empty grid gives no visual cue anything happened.
- `save()` now awaits `batchSave()` before calling `toggleMenu()`, so the reload only fires after the save has actually persisted.
- Updated `header.component.spec.ts`: `batchSave` mock now returns a resolved promise, added a test asserting `batchSave` completes before `toggleEdit` fires, and fixed a pre-existing test-isolation gap (shared `editMode` signal wasn't reset in `beforeEach`).

Fixes #315

## Test plan
- [x] `npx jest --runInBand` — 48/48 tests pass
- [x] `npx ng lint` — clean
- [x] `npx ng build` — succeeds
- [x] Manual check: add first card to an empty grid, click Save, confirm the card is present after reload without a manual refresh
