### PR TITLE
Fix version-check endpoint end-to-end (#227)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,12 @@ jobs:
         TAG_VERSION="${GITHUB_REF##*/}"
         echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
         echo "Tag version set to $TAG_VERSION"
-    
+
+    - name: Write version data file
+      run: |
+        mkdir -p Assets/VersionData
+        echo "{\"version\": \"${TAG_VERSION#v}\"}" > Assets/VersionData/versionData.json
+
     - name: build angular
       run: |
         cd Gridly-Client

--- a/Configuration/FilePaths.cs
+++ b/Configuration/FilePaths.cs
@@ -3,4 +3,5 @@ namespace Gridly.Configuration;
 public static class FilePaths
 {
     public static readonly string IconPath = Path.Combine(Directory.GetCurrentDirectory(),"Assets/Icons/");
+    public static readonly string VersionDataPath = Path.Combine(Directory.GetCurrentDirectory(),"Assets/VersionData/versionData.json");
 }

--- a/Configuration/RateLimiterPolicySettings.cs
+++ b/Configuration/RateLimiterPolicySettings.cs
@@ -1,5 +1,9 @@
+using Gridly.Constants;
 using Gridly.Models;
+using Gridly.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Gridly.Configuration;
 
@@ -7,32 +11,51 @@ public static class RateLimiterPolicySettings
 {
     public const string VersionPolicy = "version";
     public const string WeatherPolicy = "weather";
-    
+
     public static async Task<IServiceCollection> AddTokenBucketRateLimiter(this IServiceCollection services) {
 
         var versionRate = new VersionRateLimiterModel();
         var weatherRate = new WeatherRateLimiterModel();
 
-        services.AddRateLimiter(_ => _
-            .AddTokenBucketLimiter(VersionPolicy, opt =>
+        services.AddRateLimiter(options =>
+        {
+            options.OnRejected = async (context, token) =>
             {
-                opt.TokenLimit = versionRate.Limit;
-                opt.QueueLimit = versionRate.QueueLimit;
-                opt.ReplenishmentPeriod = versionRate.Window;
-                opt.TokensPerPeriod = versionRate.TokensPerPeriod;
-                opt.AutoReplenishment = true;
-            })
-            .AddTokenBucketLimiter(WeatherPolicy, opt =>
-            {
-                opt.TokenLimit = weatherRate.Limit;
-                opt.QueueLimit = weatherRate.QueueLimit;
-                opt.ReplenishmentPeriod = weatherRate.Window;
-                opt.TokensPerPeriod = weatherRate.TokensPerPeriod;
-                opt.AutoReplenishment = true;
-            }));
+                if (!context.HttpContext.Request.Path.StartsWithSegments("/api/version"))
+                {
+                    context.HttpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                    return;
+                }
+
+                var cache = context.HttpContext.RequestServices.GetRequiredService<IMemoryCashingService>();
+                var state = cache.Get<VersionCheckStateModel>(CacheKeyStrings.VersionCacheKey);
+
+                context.HttpContext.Response.StatusCode = StatusCodes.Status200OK;
+                if (state != null)
+                    await context.HttpContext.Response.WriteAsJsonAsync(state.Version, token);
+            };
+
+            options
+                .AddTokenBucketLimiter(VersionPolicy, opt =>
+                {
+                    opt.TokenLimit = versionRate.Limit;
+                    opt.QueueLimit = versionRate.QueueLimit;
+                    opt.ReplenishmentPeriod = versionRate.Window;
+                    opt.TokensPerPeriod = versionRate.TokensPerPeriod;
+                    opt.AutoReplenishment = true;
+                })
+                .AddTokenBucketLimiter(WeatherPolicy, opt =>
+                {
+                    opt.TokenLimit = weatherRate.Limit;
+                    opt.QueueLimit = weatherRate.QueueLimit;
+                    opt.ReplenishmentPeriod = weatherRate.Window;
+                    opt.TokensPerPeriod = weatherRate.TokensPerPeriod;
+                    opt.AutoReplenishment = true;
+                });
+        });
         return services;
     }
-    
+
     public static IApplicationBuilder UseTokenBucketRateLimiter(this IApplicationBuilder app)
     {
         app.UseRateLimiter();

--- a/Constants/CacheKeyStrings.cs
+++ b/Constants/CacheKeyStrings.cs
@@ -1,0 +1,6 @@
+namespace Gridly.Constants;
+
+public class CacheKeyStrings
+{
+    public const string VersionCacheKey = "version";
+}

--- a/Constants/EndpointStrings.cs
+++ b/Constants/EndpointStrings.cs
@@ -3,7 +3,6 @@ namespace Gridly.Constants;
 public class EndpointStrings
 {
     public const string GetVersionRemoteEndPoint = "https://api.github.com/repos/Carpenteri1/Gridly/releases/latest";
-    public const string GetVersionInternalEndPoint = "http://localhost:7575/api/version/latest";
     public const string materialIconsEndPoint = "https://raw.githubusercontent.com/google/material-design-icons/master/font/MaterialIcons-Regular.codepoints";
     public const string GetVisualCrossingWeatherData = "https://weather.visualcrossing.com/VisualCrossingWebServices/rest/services/timeline/{0}?key={1}";
 }

--- a/Dtos/AppVersionDtoModel.cs
+++ b/Dtos/AppVersionDtoModel.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Gridly.Dtos
+{
+    public class AppVersionDtoModel
+    {
+        [JsonPropertyName("version")]
+        public string Version { get; set; }
+    }
+}

--- a/EndPoints/IVersionEndPoint.cs
+++ b/EndPoints/IVersionEndPoint.cs
@@ -4,6 +4,5 @@ namespace Gridly.EndPoints;
 
 public interface IVersionEndPoint
 {
-    public Task<(bool, VersionModel?)> GetLatestVersion();
-    public Task<(bool, VersionModel?)> GetVersion();
+    public Task<(bool Success, VersionModel? Version)> GetLatestVersion();
 }

--- a/EndPoints/VersionEndPoint.cs
+++ b/EndPoints/VersionEndPoint.cs
@@ -5,22 +5,14 @@ using Gridly.Services;
 namespace Gridly.EndPoints;
 
 public class VersionEndPoint(
-    IDataConverter<VersionModel> dataConverter, 
+    IDataConverter<VersionModel> dataConverter,
     IHttpClientServices httpClientServices) : IVersionEndPoint
 {
-    public async Task<(bool, VersionModel?)> GetLatestVersion()
+    public async Task<(bool Success, VersionModel? Version)> GetLatestVersion()
     {
         VersionModel version = null;
         var (success,item) = await httpClientServices.Get(EndpointStrings.GetVersionRemoteEndPoint);
         if (success) version = dataConverter.DeserializeJson(item);
         return (success, version);
-    }
-
-    public async Task<(bool, VersionModel?)> GetVersion()
-    {
-        VersionModel version = null;
-       var (success,item) = await httpClientServices.Get(EndpointStrings.GetVersionInternalEndPoint);
-       if (success) version = dataConverter.DeserializeJson(item);
-       return (success, version);
     }
 }

--- a/Gridly-Client/src/app/components/header/header.component.html
+++ b/Gridly-Client/src/app/components/header/header.component.html
@@ -5,6 +5,9 @@
         <i class="bi bi-columns text-white fs-5"></i>
       </div>
       <h1 class="h4 fw-bold gradient-text m-0">{{TextStringsUtil.ClientTitle}}</h1>
+      @if(currentVersion()?.newRelease){
+        <span class="badge text-bg-info ms-2">{{TextStringsUtil.NewVersionAvailableHeaderInfoText}} {{currentVersion()!.tag_name}}</span>
+      }
     </div>
 
     <div class="navbar-collapse collapse justify-content-end" [class.show]="editActive()" id="mainNavbar" animate.enter="enter-animation">

--- a/Gridly-Client/src/app/components/header/header.component.spec.ts
+++ b/Gridly-Client/src/app/components/header/header.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
-import { of } from 'rxjs';
 import { CardModel } from '../../models/card.Model';
+import { VersionModel } from '../../models/version.Model';
 import { GridService } from '../../services/grid_services/grid.service';
 import { VersionService } from '../../services/version_services/version.service';
 import { HeaderComponent } from './header.component';
@@ -15,9 +15,10 @@ describe('HeaderComponent', () => {
   let fixture: ComponentFixture<HeaderComponent>;
   let headerComponent: HeaderComponent;
   const editMode = signal(false);
+  const currentVersion = signal<VersionModel | undefined>(undefined);
 
   const versionServiceMock = {
-    version$: of({ id: 1, name: 'v1.0.0' }),
+    currentVersion: currentVersion.asReadonly(),
   };
 
   const gridServiceMock = {
@@ -31,6 +32,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(async () => {
     editMode.set(false);
+    currentVersion.set(undefined);
     gridServiceMock.toggleEdit.mockClear();
     gridServiceMock.setEditMode.mockClear();
     gridServiceMock.addCardToFirstAvailableRow.mockClear();
@@ -97,5 +99,20 @@ describe('HeaderComponent', () => {
 
   it('renders the client title', () => {
     expect((fixture.nativeElement as HTMLElement).querySelector('h1')?.textContent).toContain('Gridly');
+  });
+
+  it('shows the new version banner when a new release is available', () => {
+    currentVersion.set({ tag_name: 'v2.0.0', newRelease: true } as VersionModel);
+    fixture.detectChanges();
+
+    const banner = (fixture.nativeElement as HTMLElement).querySelector('.badge');
+    expect(banner?.textContent).toContain('v2.0.0');
+  });
+
+  it('hides the new version banner when there is no new release', () => {
+    currentVersion.set({ tag_name: 'v1.0.0', newRelease: false } as VersionModel);
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).querySelector('.badge')).toBeNull();
   });
 });

--- a/Gridly-Client/src/app/components/header/header.component.ts
+++ b/Gridly-Client/src/app/components/header/header.component.ts
@@ -18,7 +18,7 @@ export class HeaderComponent {
   #versionService = inject(VersionService);
   #gridService = inject(GridService);
 
-  version$ = this.#versionService.version$;
+  currentVersion = this.#versionService.currentVersion;
 
   readonly TextStringsUtil = TextStringsUtil;
   addDialogActive = false;

--- a/Gridly-Client/src/app/constants/url.strings.util.ts
+++ b/Gridly-Client/src/app/constants/url.strings.util.ts
@@ -14,7 +14,7 @@ export class UrlStringsUtil {
   static readonly RowColumnUrlGet = this.RowColumnUrl+'get';
   static readonly RowColumnUrlBatchSave = this.RowColumnUrl+'batchSave';
 
-  static readonly GetVersionUrl = this.VersionUrl;
+  static readonly GetVersionUrl = this.VersionUrl+'get';
 
   static readonly GetWidgetUrl = this.WidgetUrl+'get';
 

--- a/Gridly-Client/src/app/models/version.Model.ts
+++ b/Gridly-Client/src/app/models/version.Model.ts
@@ -1,4 +1,4 @@
 export class VersionModel {
-  name!:string;
+  tag_name!:string;
   newRelease!:boolean;
 }

--- a/Gridly-Client/src/app/services/version_services/version.service.spec.ts
+++ b/Gridly-Client/src/app/services/version_services/version.service.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { VersionEndpointService } from '../endpoint_services/version.endpoint.service';
 import { VersionService } from './version.service';
 
 describe('VersionService', () => {
-  const version = { id: 1, name: 'v1.2.3' };
+  const version = { tag_name: 'v1.2.3', newRelease: false };
   const endpointMock = {
     get: jest.fn(() => of(version)),
   };
@@ -24,5 +24,15 @@ describe('VersionService', () => {
 
     expect(endpointMock.get).toHaveBeenCalledTimes(1);
     expect(service.currentVersion()).toEqual(version);
+  });
+
+  it('resolves to undefined when the endpoint call fails', () => {
+    TestBed.overrideProvider(VersionEndpointService, {
+      useValue: { get: jest.fn(() => throwError(() => new Error('network error'))) },
+    });
+
+    const service = TestBed.inject(VersionService);
+
+    expect(service.currentVersion()).toBeUndefined();
   });
 });

--- a/Gridly-Client/src/app/services/version_services/version.service.ts
+++ b/Gridly-Client/src/app/services/version_services/version.service.ts
@@ -1,14 +1,14 @@
 import {inject, Injectable, Signal} from "@angular/core";
 import {VersionModel} from "../../models/version.Model";
 import {VersionEndpointService} from "../endpoint_services/version.endpoint.service";
-import {Observable} from "rxjs";
+import {catchError, Observable, of} from "rxjs";
 import { toSignal } from "@angular/core/rxjs-interop";
 
 @Injectable({providedIn: 'root'})
 export class VersionService {
     #api = inject(VersionEndpointService);
 
-    version$: Observable<VersionModel>;
+    version$: Observable<VersionModel | undefined>;
 
     readonly currentVersion: Signal<VersionModel | undefined>;
 
@@ -17,5 +17,5 @@ export class VersionService {
         this.currentVersion = toSignal(this.version$);
     }
 
-    getVersion$ = () => this.#api.get();
+    getVersion$ = () => this.#api.get().pipe(catchError(() => of(undefined)));
 }

--- a/Handlers/VersionHandler.cs
+++ b/Handlers/VersionHandler.cs
@@ -1,3 +1,4 @@
+using Gridly.Constants;
 using Gridly.Querys;
 using Gridly.EndPoints;
 using Gridly.Models;
@@ -8,32 +9,46 @@ namespace Gridly.Handlers;
 
 public class VersionHandler(
     IVersionEndPoint versionEndPoint,
-    IMemoryCashingService memoryCashingService) : 
+    IMemoryCashingService memoryCashingService,
+    IAppVersionProvider appVersionProvider) :
     IRequestHandler<GetVersionQuery, IResult>,
     IRequestHandler<GetLatestVersionQuery, IResult>
 {
+    private static readonly TimeSpan CheckInterval = new VersionRateLimiterModel().Window;
+
     public async Task<IResult> Handle(GetVersionQuery query, CancellationToken cancellationToken)
     {
-        var cashedVersion = memoryCashingService.Get<VersionModel>("version");
-        if (cashedVersion == null)
-        {
-            var (success, version) = await versionEndPoint.GetVersion();
-            if (success)
-            {
-                memoryCashingService.Store("version", version!);
-                cashedVersion = version;
-            }
-        }
-
-        return cashedVersion != null ? Results.Ok(cashedVersion) : Results.NotFound();
+        var state = memoryCashingService.Get<VersionCheckStateModel>(CacheKeyStrings.VersionCacheKey);
+        return state != null ? Results.Ok(state.Version) : Results.NotFound();
     }
 
     public async Task<IResult> Handle(GetLatestVersionQuery query, CancellationToken cancellationToken)
     {
+        var state = memoryCashingService.Get<VersionCheckStateModel>(CacheKeyStrings.VersionCacheKey);
+        if (state != null && DateTime.UtcNow - state.CheckedAtUtc < CheckInterval)
+            return Results.Ok(state.Version);
+
         var (success, remoteVersion) = await versionEndPoint.GetLatestVersion();
-        if(success)
-            memoryCashingService.Store("version", remoteVersion!);
-        
-        return success ? Results.Ok(remoteVersion) : Results.NotFound();
+        if (!success)
+            return state != null ? Results.Ok(state.Version) : Results.NotFound();
+
+        var currentVersion = await appVersionProvider.GetCurrentVersionAsync();
+        remoteVersion!.NewRelease = HasNewRelease(currentVersion, remoteVersion.Name);
+
+        var newState = new VersionCheckStateModel { Version = remoteVersion, CheckedAtUtc = DateTime.UtcNow };
+        memoryCashingService.Store(CacheKeyStrings.VersionCacheKey, newState, CheckInterval);
+
+        return Results.Ok(remoteVersion);
     }
+
+    private static bool HasNewRelease(string currentVersion, string latestVersion)
+    {
+        if (string.Equals(currentVersion, AppVersionProvider.DevSentinelVersion, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return !string.Equals(Normalize(currentVersion), Normalize(latestVersion), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Normalize(string version) =>
+        version?.TrimStart('v', 'V').Trim() ?? string.Empty;
 }

--- a/Models/VersionCheckStateModel.cs
+++ b/Models/VersionCheckStateModel.cs
@@ -1,0 +1,7 @@
+namespace Gridly.Models;
+
+public class VersionCheckStateModel
+{
+    public VersionModel Version { get; set; }
+    public DateTime CheckedAtUtc { get; set; }
+}

--- a/Models/VersionModel.cs
+++ b/Models/VersionModel.cs
@@ -4,7 +4,7 @@ namespace Gridly.Models;
 
 public class VersionModel
 {
-    [JsonPropertyName("name")]
+    [JsonPropertyName("tag_name")]
     public string Name { get; set; }
     [JsonPropertyName("newRelease")]
     public bool NewRelease { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -34,8 +34,10 @@ builder.Services.AddSingleton<IMemoryCashingService, MemoryCashingServices>();
 builder.Services.AddSingleton<IHttpClientServices, HttpClientServices>();
 builder.Services.AddSingleton<IFileService, FileService>();
 builder.Services.AddSingleton(typeof(IDataConverter<>), typeof(DataConverter<>));
+builder.Services.AddSingleton<IAppVersionProvider, AppVersionProvider>();
+builder.Services.AddHostedService<VersionCheckBackgroundService>();
 
-builder.Services.AddMediatR(cfg => 
+builder.Services.AddMediatR(cfg =>
     cfg.RegisterServicesFromAssemblies(AppDomain.CurrentDomain.GetAssemblies()));
 var app = builder.Build();
 

--- a/Services/AppVersionProvider.cs
+++ b/Services/AppVersionProvider.cs
@@ -1,0 +1,29 @@
+using Gridly.Configuration;
+using Gridly.Dtos;
+
+namespace Gridly.Services;
+
+public class AppVersionProvider(
+    IFileService fileService,
+    IDataConverter<AppVersionDtoModel> dataConverter) : IAppVersionProvider
+{
+    public const string DevSentinelVersion = "0.0.0";
+
+    public async Task<string> GetCurrentVersionAsync()
+    {
+        if (!fileService.FileExist(FilePaths.VersionDataPath))
+            return DevSentinelVersion;
+
+        try
+        {
+            var content = await fileService.ReadAllFromFileAsync(FilePaths.VersionDataPath);
+            var data = dataConverter.DeserializeJson(content);
+            return data?.Version ?? DevSentinelVersion;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            return DevSentinelVersion;
+        }
+    }
+}

--- a/Services/IAppVersionProvider.cs
+++ b/Services/IAppVersionProvider.cs
@@ -1,0 +1,6 @@
+namespace Gridly.Services;
+
+public interface IAppVersionProvider
+{
+    Task<string> GetCurrentVersionAsync();
+}

--- a/Services/IMemoryCashingServices.cs
+++ b/Services/IMemoryCashingServices.cs
@@ -3,5 +3,5 @@ namespace Gridly.Services;
 public interface IMemoryCashingService
 {
     public T? Get<T>(string key) where T : class;
-    public bool Store<T>(string key, T item) where T : class;
+    public bool Store<T>(string key, T item, TimeSpan? absoluteExpiration = null) where T : class;
 }

--- a/Services/MemoryCashingServices.cs
+++ b/Services/MemoryCashingServices.cs
@@ -6,12 +6,12 @@ public class MemoryCashingServices(IMemoryCache memoryCache) : IMemoryCashingSer
     
 {
     public T Get<T>(string key) where T : class => memoryCache.Get<T>(key);
-    public bool Store<T>(string key, T item) where T : class => 
+    public bool Store<T>(string key, T item, TimeSpan? absoluteExpiration = null) where T : class =>
         memoryCache.Set(
-            key, 
-            item, 
+            key,
+            item,
             new MemoryCacheEntryOptions
             {
-                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(60)
+                AbsoluteExpirationRelativeToNow = absoluteExpiration ?? TimeSpan.FromMinutes(60)
             }) is T;
 }

--- a/Services/VersionCheckBackgroundService.cs
+++ b/Services/VersionCheckBackgroundService.cs
@@ -1,0 +1,41 @@
+using Gridly.Models;
+using Gridly.Querys;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Gridly.Services;
+
+public class VersionCheckBackgroundService(IServiceScopeFactory serviceScopeFactory) : BackgroundService
+{
+    private static readonly TimeSpan Interval = new VersionRateLimiterModel().Window;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await CheckVersionAsync(stoppingToken);
+            try
+            {
+                await Task.Delay(Interval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+
+    private async Task CheckVersionAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = serviceScopeFactory.CreateScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            await mediator.Send(new GetLatestVersionQuery(), cancellationToken);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+        }
+    }
+}

--- a/Tests/Handlers/VersionHandlerTests.cs
+++ b/Tests/Handlers/VersionHandlerTests.cs
@@ -1,6 +1,8 @@
+using Gridly.Constants;
 using Gridly.Querys;
 using Gridly.Handlers;
 using Gridly.Models;
+using Gridly.Services;
 using Gridly.Tests.Infrastructure;
 
 namespace Gridly.Tests.Handlers;
@@ -8,80 +10,144 @@ namespace Gridly.Tests.Handlers;
 public class VersionHandlerTests
 {
     [Fact]
-    public async Task HandleGetVersion_WhenCached_ReturnsCachedVersionWithoutCallingEndpoint()
+    public async Task HandleGetVersion_WhenNoCache_ReturnsNotFoundWithoutCallingEndpoint()
+    {
+        var cache = new FakeMemoryCashingService();
+        var endPoint = new FakeVersionEndPoint();
+        var appVersionProvider = new FakeAppVersionProvider();
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
+
+        var result = await handler.Handle(new GetVersionQuery(), CancellationToken.None);
+
+        ResultAssertions.AssertStatusCode(result, StatusCodes.Status404NotFound);
+        Assert.Equal(0, endPoint.GetLatestVersionCallCount);
+        Assert.Equal(0, appVersionProvider.CallCount);
+    }
+
+    [Fact]
+    public async Task HandleGetVersion_WhenCached_ReturnsCachedVersionWithoutCallingGitHub()
     {
         var cache = new FakeMemoryCashingService();
         var cachedVersion = new VersionModel { Name = "1.0.0", NewRelease = false };
-        cache.Seed("version", cachedVersion);
+        cache.Seed(CacheKeyStrings.VersionCacheKey,
+            new VersionCheckStateModel { Version = cachedVersion, CheckedAtUtc = DateTime.UtcNow });
         var endPoint = new FakeVersionEndPoint();
-        var handler = new VersionHandler(endPoint, cache);
+        var appVersionProvider = new FakeAppVersionProvider();
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
 
         var result = await handler.Handle(new GetVersionQuery(), CancellationToken.None);
         var payload = ResultAssertions.AssertOk<VersionModel>(result);
 
         Assert.Equal(cachedVersion.Name, payload.Name);
-        Assert.Equal(0, endPoint.GetVersionCallCount);
+        Assert.Equal(0, endPoint.GetLatestVersionCallCount);
     }
 
     [Fact]
-    public async Task HandleGetVersion_WhenRemoteFetchSucceeds_StoresAndReturnsVersion()
+    public async Task HandleGetLatestVersion_WhenCachedAndFresh_ReturnsCachedValueWithoutCallingGitHub()
     {
-        var version = new VersionModel { Name = "2.0.0", NewRelease = true };
-        var endPoint = new FakeVersionEndPoint { GetVersionResult = (true, version) };
         var cache = new FakeMemoryCashingService();
-        var handler = new VersionHandler(endPoint, cache);
-
-        var result = await handler.Handle(new GetVersionQuery(), CancellationToken.None);
-        var payload = ResultAssertions.AssertOk<VersionModel>(result);
-
-        Assert.Equal(version.Name, payload.Name);
-        Assert.Equal(1, endPoint.GetVersionCallCount);
-        Assert.Equal(1, cache.StoreCallCount);
-        Assert.Equal("version", cache.LastStoredKey);
-        Assert.Same(version, cache.LastStoredValue);
-    }
-
-    [Fact]
-    public async Task HandleGetVersion_WhenRemoteFetchFails_ReturnsNotFound()
-    {
-        var endPoint = new FakeVersionEndPoint { GetVersionResult = (false, null) };
-        var cache = new FakeMemoryCashingService();
-        var handler = new VersionHandler(endPoint, cache);
-
-        var result = await handler.Handle(new GetVersionQuery(), CancellationToken.None);
-
-        ResultAssertions.AssertStatusCode(result, StatusCodes.Status404NotFound);
-        Assert.Equal(1, endPoint.GetVersionCallCount);
-        Assert.Equal(0, cache.StoreCallCount);
-    }
-
-    [Fact]
-    public async Task HandleGetLatestVersion_WhenRemoteFetchSucceeds_StoresAndReturnsVersion()
-    {
-        var version = new VersionModel { Name = "3.0.0", NewRelease = true };
-        var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (true, version) };
-        var cache = new FakeMemoryCashingService();
-        var handler = new VersionHandler(endPoint, cache);
+        var cachedVersion = new VersionModel { Name = "1.0.0", NewRelease = false };
+        cache.Seed(CacheKeyStrings.VersionCacheKey,
+            new VersionCheckStateModel { Version = cachedVersion, CheckedAtUtc = DateTime.UtcNow.AddHours(-1) });
+        var endPoint = new FakeVersionEndPoint();
+        var appVersionProvider = new FakeAppVersionProvider();
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
 
         var result = await handler.Handle(new GetLatestVersionQuery(), CancellationToken.None);
         var payload = ResultAssertions.AssertOk<VersionModel>(result);
 
-        Assert.Equal(version.Name, payload.Name);
-        Assert.Equal(1, endPoint.GetLatestVersionCallCount);
-        Assert.Equal(1, cache.StoreCallCount);
+        Assert.Equal(cachedVersion.Name, payload.Name);
+        Assert.Equal(0, endPoint.GetLatestVersionCallCount);
+        Assert.Equal(0, appVersionProvider.CallCount);
     }
 
     [Fact]
-    public async Task HandleGetLatestVersion_WhenRemoteFetchFails_ReturnsNotFound()
+    public async Task HandleGetLatestVersion_WhenCacheStale_RefetchesFromGitHub()
     {
+        var cache = new FakeMemoryCashingService();
+        var staleVersion = new VersionModel { Name = "1.0.0", NewRelease = false };
+        cache.Seed(CacheKeyStrings.VersionCacheKey,
+            new VersionCheckStateModel { Version = staleVersion, CheckedAtUtc = DateTime.UtcNow.AddHours(-9) });
+        var latestVersion = new VersionModel { Name = "2.0.0" };
+        var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (true, latestVersion) };
+        var appVersionProvider = new FakeAppVersionProvider { CurrentVersion = "1.0.0" };
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
+
+        var result = await handler.Handle(new GetLatestVersionQuery(), CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<VersionModel>(result);
+
+        Assert.Equal(1, endPoint.GetLatestVersionCallCount);
+        Assert.Equal("2.0.0", payload.Name);
+        Assert.True(payload.NewRelease);
+        Assert.Equal(1, cache.StoreCallCount);
+        Assert.NotNull(cache.LastStoredExpiration);
+    }
+
+    [Fact]
+    public async Task HandleGetLatestVersion_WhenGitHubFailsWithStaleCache_ReturnsStaleCachedValue()
+    {
+        var cache = new FakeMemoryCashingService();
+        var staleVersion = new VersionModel { Name = "1.0.0", NewRelease = false };
+        cache.Seed(CacheKeyStrings.VersionCacheKey,
+            new VersionCheckStateModel { Version = staleVersion, CheckedAtUtc = DateTime.UtcNow.AddHours(-9) });
         var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (false, null) };
+        var appVersionProvider = new FakeAppVersionProvider();
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
+
+        var result = await handler.Handle(new GetLatestVersionQuery(), CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<VersionModel>(result);
+
+        Assert.Equal(staleVersion.Name, payload.Name);
+        Assert.Equal(0, cache.StoreCallCount);
+    }
+
+    [Fact]
+    public async Task HandleGetLatestVersion_WhenGitHubFailsWithNoCache_ReturnsNotFound()
+    {
         var cache = new FakeMemoryCashingService();
-        var handler = new VersionHandler(endPoint, cache);
+        var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (false, null) };
+        var appVersionProvider = new FakeAppVersionProvider();
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
 
         var result = await handler.Handle(new GetLatestVersionQuery(), CancellationToken.None);
 
         ResultAssertions.AssertStatusCode(result, StatusCodes.Status404NotFound);
         Assert.Equal(1, endPoint.GetLatestVersionCallCount);
         Assert.Equal(0, cache.StoreCallCount);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", "1.0.0", false)]
+    [InlineData("1.0.0", "v1.0.0", false)]
+    [InlineData("V1.0.0", "v1.0.0", false)]
+    [InlineData("1.0.0", "2.0.0", true)]
+    public async Task HandleGetLatestVersion_ComparesCurrentVersionAgainstLatest(
+        string currentVersion, string latestVersionName, bool expectedNewRelease)
+    {
+        var cache = new FakeMemoryCashingService();
+        var latestVersion = new VersionModel { Name = latestVersionName };
+        var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (true, latestVersion) };
+        var appVersionProvider = new FakeAppVersionProvider { CurrentVersion = currentVersion };
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
+
+        var result = await handler.Handle(new GetLatestVersionQuery(), CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<VersionModel>(result);
+
+        Assert.Equal(expectedNewRelease, payload.NewRelease);
+    }
+
+    [Fact]
+    public async Task HandleGetLatestVersion_WhenCurrentVersionIsDevSentinel_NeverReportsNewRelease()
+    {
+        var cache = new FakeMemoryCashingService();
+        var latestVersion = new VersionModel { Name = "5.0.0" };
+        var endPoint = new FakeVersionEndPoint { GetLatestVersionResult = (true, latestVersion) };
+        var appVersionProvider = new FakeAppVersionProvider { CurrentVersion = AppVersionProvider.DevSentinelVersion };
+        var handler = new VersionHandler(endPoint, cache, appVersionProvider);
+
+        var result = await handler.Handle(new GetLatestVersionQuery(), CancellationToken.None);
+        var payload = ResultAssertions.AssertOk<VersionModel>(result);
+
+        Assert.False(payload.NewRelease);
     }
 }

--- a/Tests/Infrastructure/TestDoubles.cs
+++ b/Tests/Infrastructure/TestDoubles.cs
@@ -40,6 +40,7 @@ internal sealed class FakeMemoryCashingService : IMemoryCashingService
     public int StoreCallCount { get; private set; }
     public string? LastStoredKey { get; private set; }
     public object? LastStoredValue { get; private set; }
+    public TimeSpan? LastStoredExpiration { get; private set; }
 
     public T? Get<T>(string key) where T : class
     {
@@ -47,11 +48,12 @@ internal sealed class FakeMemoryCashingService : IMemoryCashingService
         return _cache.TryGetValue(key, out var value) ? value as T : null;
     }
 
-    public bool Store<T>(string key, T item) where T : class
+    public bool Store<T>(string key, T item, TimeSpan? absoluteExpiration = null) where T : class
     {
         StoreCallCount++;
         LastStoredKey = key;
         LastStoredValue = item;
+        LastStoredExpiration = absoluteExpiration;
         _cache[key] = item;
         return true;
     }
@@ -64,21 +66,25 @@ internal sealed class FakeMemoryCashingService : IMemoryCashingService
 
 internal sealed class FakeVersionEndPoint : IVersionEndPoint
 {
-    public int GetVersionCallCount { get; private set; }
     public int GetLatestVersionCallCount { get; private set; }
-    public (bool Success, VersionModel? Version) GetVersionResult { get; set; }
     public (bool Success, VersionModel? Version) GetLatestVersionResult { get; set; }
 
-    public Task<(bool, VersionModel?)> GetLatestVersion()
+    public Task<(bool Success, VersionModel? Version)> GetLatestVersion()
     {
         GetLatestVersionCallCount++;
         return Task.FromResult((GetLatestVersionResult.Success, GetLatestVersionResult.Version));
     }
+}
 
-    public Task<(bool, VersionModel?)> GetVersion()
+internal sealed class FakeAppVersionProvider : IAppVersionProvider
+{
+    public int CallCount { get; private set; }
+    public string CurrentVersion { get; set; } = "1.0.0";
+
+    public Task<string> GetCurrentVersionAsync()
     {
-        GetVersionCallCount++;
-        return Task.FromResult((GetVersionResult.Success, GetVersionResult.Version));
+        CallCount++;
+        return Task.FromResult(CurrentVersion);
     }
 }
 

--- a/Tests/Services/DataConverterTests.cs
+++ b/Tests/Services/DataConverterTests.cs
@@ -11,7 +11,7 @@ public class DataConverterTests
     [Fact]
     public void DeserializeJson_ReturnsObject()
     {
-        const string json = """{"name":"1.2.3","newRelease":true}""";
+        const string json = """{"tag_name":"1.2.3","newRelease":true}""";
 
         var result = _converter.DeserializeJson(json);
 
@@ -23,7 +23,7 @@ public class DataConverterTests
     [Fact]
     public void DeserializeJsonToArray_ReturnsArray()
     {
-        const string json = """[{"name":"1.0.0","newRelease":false},{"name":"1.1.0","newRelease":true}]""";
+        const string json = """[{"tag_name":"1.0.0","newRelease":false},{"tag_name":"1.1.0","newRelease":true}]""";
 
         var result = _converter.DeserializeJsonToArray(json);
 
@@ -45,7 +45,7 @@ public class DataConverterTests
 
         var result = _converter.SerializerToJsonString(model);
 
-        Assert.Equal("""{"name":"2.0.0","newRelease":true}""", result);
+        Assert.Equal("""{"tag_name":"2.0.0","newRelease":true}""", result);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class DataConverterTests
 
         var result = _converter.SerializerToJsonString(models);
 
-        Assert.Equal("""[{"name":"1.0.0","newRelease":false},{"name":"2.0.0","newRelease":true}]""", result);
+        Assert.Equal("""[{"tag_name":"1.0.0","newRelease":false},{"tag_name":"2.0.0","newRelease":true}]""", result);
     }
 
     [Fact]


### PR DESCRIPTION
The internal /api/version/latest handler was actually a loopback HTTP call to the app's own port instead of a local version read, and NewRelease was never computed anywhere. Rewrite VersionHandler so GetVersionQuery is a pure local cache read, and GetLatestVersionQuery is the only path that calls GitHub, gated by an 8h cache (enforced in the handler itself, not just the ASP.NET Core rate limiter, since the new background job bypasses HTTP entirely).

- Add IAppVersionProvider, reading the running version from Assets/VersionData/versionData.json (written by the release workflow), falling back to a "0.0.0" dev sentinel when unpublished.
- Add VersionCheckBackgroundService to recheck every 8h on top of the on-demand endpoint.
- Give IMemoryCashingService.Store an optional TTL instead of a hardcoded 60 minutes, and add an OnRejected handler so a rate-limited /api/version/* request gets a cached 200 instead of the default 503.
- Rename VersionModel's JSON property from "name" to "tag_name" to match GitHub's actual release field, and update the Angular client/tests to match; fix GetVersionUrl to point at /api/version/get and add the missing new-release banner in the header.


Claude-Session: https://claude.ai/code/session_01PzwrZiKCg45nwYrQstXsKS