### PR TITLE
Add missing frontend Jest tests and enforce 80% coverage (#317)

### DIFF
--- a/.github/workflows/Build_Test_Branches.yml
+++ b/.github/workflows/Build_Test_Branches.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: ${{ env.ANGULAR_PATH }}
 
       - name: Test Angular with Jest
-        run: npm test -- --runInBand
+        run: npm test -- --runInBand --coverage
         working-directory: ${{ env.ANGULAR_PATH }}
 
       - name: Restore .NET dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/
 obj/
 Gridly-Client/publish/
 Gridly-Client/dist
+Gridly-Client/coverage
 Gridly-Client/package-lock.json
 .vs/*
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,9 @@ Stores icons, images, and other static assets needed by the app. A dedicated con
 Organized by responsibility: UI components, a services layer (split between low-level per-resource HTTP calls and higher-level services that use them), plus shared models/DTOs/interfaces/type definitions. Domain concepts that have multiple variants (e.g. different kinds of cards/widgets) are defined as an enum/type list, with room to add new variants without restructuring existing code. Not every variant needs to be fully implemented at once — a variant can be scaffolded (reference data, a type entry, a placeholder in the UI) ahead of its backend implementation being built.
 
 ### Tests
-Organized to mirror the main source layout — one test area per layer (handlers, repositories, mapping/factory logic, services), with shared test infrastructure (fakes/doubles and result-assertion helpers) factored out so individual tests stay focused on behavior rather than setup.
+Backend tests are organized to mirror the main source layout — one test area per layer (handlers, repositories, mapping/factory logic, services), with shared test infrastructure (fakes/doubles and result-assertion helpers) factored out so individual tests stay focused on behavior rather than setup.
+
+Frontend (`Gridly-Client`) tests are Jest specs colocated with their source under `src/app/**/*.spec.ts`, run via `npm test` (`jest --runInBand --coverage`). HTTP-boundary endpoint services are tested with `provideHttpClient()` + `provideHttpClientTesting()`/`HttpTestingController`, asserting the request rather than calling a real API; higher-level services and components instead mock their injected endpoint/business services directly with `jest.fn()`. All tests must maintain at least 80% coverage across branches, functions, lines, and statements, enforced via `coverageThreshold` in `jest.config.js` — if a change drops any category below 80%, more tests must be added before that change is considered done, since a Jest run that misses the threshold fails automatically.
 
 ### Git workflow, branching & pull requests
 The repo uses a two-tier branch model, not direct-to-main feature branches:

--- a/Gridly-Client/jest.config.js
+++ b/Gridly-Client/jest.config.js
@@ -5,4 +5,25 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
   testEnvironment: 'jsdom',
   testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  collectCoverageFrom: [
+    'src/app/**/*.ts',
+    '!src/app/**/*.spec.ts',
+    '!src/app/models/**',
+    '!src/app/dtos/**',
+    '!src/app/interfaces/**',
+    '!src/app/enums/**',
+    '!src/app/constants/**',
+    '!src/app/testing/**',
+    '!src/app/app.config.ts',
+    '!src/app/app.config.server.ts',
+  ],
+  coverageReporters: ['text', 'json-summary', 'lcov'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };

--- a/Gridly-Client/package.json
+++ b/Gridly-Client/package.json
@@ -5,7 +5,7 @@
     "build": "ng build",
     "lint": "ng lint",
     "watch": "ng build --watch --configuration development",
-    "test": "jest --runInBand",
+    "test": "jest --runInBand --coverage",
     "node-run": "node dist/gridly-client/server/server.mjs",
     "start": "gulp build-angular-net",
     "start-angular": "gulp build-angular"

--- a/Gridly-Client/src/app/components/card/card.component.spec.ts
+++ b/Gridly-Client/src/app/components/card/card.component.spec.ts
@@ -13,6 +13,7 @@ import { DeleteCardDialogComponent } from '../dialogs/deleteCardDialog/delete-ca
 import { ProviderKeyDialogComponent } from '../dialogs/apiKeyDialog/provider-key-dialog.component';
 import { SetLocationForProviderDialogComponent } from '../dialogs/setLocationForProviderDialog/set-location-for-provider-dialog.component';
 import { StubTranslatePipe } from '../../testing/stub-translate.pipe';
+import { DialogService } from '../../services/dialog_services/dialog.service';
 import { CardComponent } from './card.component';
 
 type CardComponentFixture = CardComponent & {
@@ -93,27 +94,69 @@ describe('CardComponent', () => {
     expect(element.querySelector('mat-icon')?.textContent).toContain('cloud');
     expect(element.textContent).toContain('Weather');
   });
-  /*TODO add test later
-  it('opens the edit and delete dialogs from the card methods', () => {
-    createCardComponent.openEditDialog();
+  it('opens the edit, delete and add-provider-key dialogs for the current card', async () => {
+    await createCardComponent.openEditDialog();
     createCardComponent.openDeleteDialog();
-    createCardComponent.openAddProviderKeyDialog()
+    createCardComponent.openAddProviderKeyDialog();
 
-    expect(createCardComponent.isEditDialogOpen).toBe(true);
-    expect(createCardComponent.isDeleteDialogOpen).toBe(true);
-    expect(createCardComponent.isProviderDialogOpen).toBe(true);
+    expect(createCardComponent.isEditDialogOpenForCard()).toBe(true);
+    expect(createCardComponent.isDeleteDialogOpenForCard()).toBe(true);
+    expect(createCardComponent.isAddProviderKeyDialogOpen()).toBe(true);
   });
 
+  it('closes both the edit and delete dialogs when the matching dialog id is emitted', async () => {
+    await createCardComponent.openEditDialog();
+    createCardComponent.openDeleteDialog();
 
-  it('closes both dialogs when the matching dialog id is emitted', () => {
-    createCardComponent.isEditDialogOpen = true;
-    createCardComponent.isDeleteDialogOpen = true;
+    createCardComponent.handleDialogChange(currentCard.id);
 
-    createCardComponent.handleDialogChange(7);
+    expect(createCardComponent.isEditDialogOpenForCard()).toBe(false);
+    expect(createCardComponent.isDeleteDialogOpenForCard()).toBe(false);
+  });
 
-    expect(createCardComponent.isEditDialogOpen).toBe(false);
-    expect(createCardComponent.isDeleteDialogOpen).toBe(false);
-  });*/
+  it('leaves the dialogs open when a non-matching dialog id is emitted', async () => {
+    await createCardComponent.openEditDialog();
+
+    createCardComponent.handleDialogChange(currentCard.id + 1);
+
+    expect(createCardComponent.isEditDialogOpenForCard()).toBe(true);
+  });
+
+  it('closes the api key dialog and opens the location dialog once no key dialog remains open', () => {
+    createCardComponent.openAddProviderKeyDialog();
+
+    (createCardComponent as unknown as { SaveProviderKey(id: number): void }).SaveProviderKey(currentCard.id);
+
+    expect(createCardComponent.isAddProviderKeyDialogOpen()).toBe(false);
+    expect(createCardComponent.isSetProviderLocationDialogOpen()).toBe(true);
+  });
+
+  it('does not open the location dialog while another card still has the key dialog open', () => {
+    const dialogService = TestBed.inject(DialogService);
+    dialogService.openProviderKeyDialog(currentCard.id + 1);
+
+    (createCardComponent as unknown as { SaveProviderKey(id: number): void }).SaveProviderKey(currentCard.id + 1);
+
+    expect(createCardComponent.isSetProviderLocationDialogOpen()).toBe(false);
+  });
+
+  it('closes the location dialog when the matching dialog id is emitted', () => {
+    const dialogService = TestBed.inject(DialogService);
+    dialogService.openSetProviderLocationDialog(currentCard.id);
+
+    (createCardComponent as unknown as { SaveProviderLocation(id: number): void }).SaveProviderLocation(currentCard.id);
+
+    expect(createCardComponent.isSetProviderLocationDialogOpen()).toBe(false);
+  });
+
+  it('leaves the location dialog open when a non-matching dialog id is emitted', () => {
+    const dialogService = TestBed.inject(DialogService);
+    dialogService.openSetProviderLocationDialog(currentCard.id);
+
+    (createCardComponent as unknown as { SaveProviderLocation(id: number): void }).SaveProviderLocation(currentCard.id + 1);
+
+    expect(createCardComponent.isSetProviderLocationDialogOpen()).toBe(true);
+  });
 
   it('delegates edit and remove actions to the grid service', () => {
     (createCardComponent as CardComponentFixture).edit(currentCard);

--- a/Gridly-Client/src/app/components/dialogs/apiKeyDialog/provider-key-dialog.component.spec.ts
+++ b/Gridly-Client/src/app/components/dialogs/apiKeyDialog/provider-key-dialog.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AsyncPipe } from '@angular/common';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+import { ProviderKeysService } from '../../../services/provider_key_services/provider-keys.service';
+import { ThirdPartyProvider } from '../../../enums/third-party-provider.enum';
+import { StubTranslatePipe } from '../../../testing/stub-translate.pipe';
+import { ProviderKeyDialogComponent } from './provider-key-dialog.component';
+
+describe('ProviderKeyDialogComponent', () => {
+  let fixture: ComponentFixture<ProviderKeyDialogComponent>;
+  let component: ProviderKeyDialogComponent;
+
+  const providerKeysServiceMock = {
+    save: jest.fn(),
+    onKeySaved: jest.fn(),
+  };
+
+  const translateServiceMock = {
+    instant: (key: string) => key,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    providerKeysServiceMock.onKeySaved.mockResolvedValue(undefined);
+
+    TestBed.configureTestingModule({
+      imports: [ProviderKeyDialogComponent],
+      providers: [
+        { provide: ProviderKeysService, useValue: providerKeysServiceMock },
+        { provide: TranslateService, useValue: translateServiceMock },
+      ],
+    }).overrideComponent(ProviderKeyDialogComponent, {
+      remove: { imports: [TranslatePipe] },
+      add: { imports: [AsyncPipe, StubTranslatePipe] },
+    });
+
+    fixture = TestBed.createComponent(ProviderKeyDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    jest.spyOn(component, 'close').mockImplementation(() => undefined);
+  });
+
+  it('does nothing when the raw key is empty or whitespace', () => {
+    component.rawKey = '   ';
+
+    component.onSubmit();
+
+    expect(providerKeysServiceMock.save).not.toHaveBeenCalled();
+  });
+
+  it('saves the trimmed key and closes on success', async () => {
+    providerKeysServiceMock.save.mockReturnValue(of(undefined));
+    const keySavedSpy = jest.spyOn(component.keySaved, 'emit');
+    component.rawKey = '  my-key  ';
+
+    component.onSubmit();
+    await fixture.whenStable();
+
+    expect(providerKeysServiceMock.save).toHaveBeenCalledWith('my-key', ThirdPartyProvider.VisualCrossing);
+    expect(component.saving).toBe(false);
+    expect(component.rawKey).toBe('');
+    expect(providerKeysServiceMock.onKeySaved).toHaveBeenCalledWith(ThirdPartyProvider.VisualCrossing);
+    expect(component.close).toHaveBeenCalled();
+    expect(keySavedSpy).toHaveBeenCalled();
+  });
+
+  it('sets a translated error message when saving fails', () => {
+    providerKeysServiceMock.save.mockReturnValue(throwError(() => new Error('boom')));
+    component.rawKey = 'my-key';
+
+    component.onSubmit();
+
+    expect(component.saving).toBe(false);
+    expect(component.errorMessage).toBe('apiKeyDialog.text.saveFailedMessage');
+  });
+});

--- a/Gridly-Client/src/app/components/dialogs/deleteCardDialog/delete-card-dialog.component.spec.ts
+++ b/Gridly-Client/src/app/components/dialogs/deleteCardDialog/delete-card-dialog.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AsyncPipe } from '@angular/common';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { StubTranslatePipe } from '../../../testing/stub-translate.pipe';
+import { DeleteCardDialogComponent } from './delete-card-dialog.component';
+
+describe('DeleteCardDialogComponent', () => {
+  let fixture: ComponentFixture<DeleteCardDialogComponent>;
+  let component: DeleteCardDialogComponent;
+
+  const translateServiceMock = {
+    instant: (key: string) => key,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [DeleteCardDialogComponent],
+      providers: [{ provide: TranslateService, useValue: translateServiceMock }],
+    }).overrideComponent(DeleteCardDialogComponent, {
+      remove: { imports: [TranslatePipe] },
+      add: { imports: [AsyncPipe, StubTranslatePipe] },
+    });
+
+    fixture = TestBed.createComponent(DeleteCardDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('closes and emits the card id to remove on submit', () => {
+    jest.spyOn(component, 'close').mockImplementation(() => undefined);
+    const removeSpy = jest.spyOn(component.remove, 'emit');
+    component.id = 42;
+
+    component.onSubmit();
+
+    expect(component.close).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith({ id: 42 });
+  });
+});

--- a/Gridly-Client/src/app/components/dialogs/editCardDialog/edit-card-dialog.component.spec.ts
+++ b/Gridly-Client/src/app/components/dialogs/editCardDialog/edit-card-dialog.component.spec.ts
@@ -1,0 +1,127 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AsyncPipe } from '@angular/common';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { StubTranslatePipe } from '../../../testing/stub-translate.pipe';
+import { CardModel } from '../../../models/card.Model';
+import { EditCardDialogFacade } from './edit-card-dialog.facade';
+import { EditCardDialogComponent } from './edit-card-dialog.component';
+
+describe('EditCardDialogComponent', () => {
+  let fixture: ComponentFixture<EditCardDialogComponent>;
+  let component: EditCardDialogComponent;
+
+  const facadeMock = {
+    card: new CardModel(),
+    icons$: of(null),
+    countryInput: '',
+    cityInput: '',
+    errorStatus: 0,
+    isWeatherCard: false,
+    onSearch: jest.fn(),
+    setIcon: jest.fn(),
+    saveLocation: jest.fn(),
+    buildSubmitPayload: jest.fn(),
+    reset: jest.fn(),
+  };
+
+  const translateServiceMock = {
+    instant: (key: string) => key,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    facadeMock.isWeatherCard = false;
+    facadeMock.card = new CardModel();
+
+    TestBed.configureTestingModule({
+      imports: [EditCardDialogComponent],
+      providers: [{ provide: TranslateService, useValue: translateServiceMock }],
+    })
+      .overrideComponent(EditCardDialogComponent, {
+        remove: { imports: [TranslatePipe] },
+        add: { imports: [AsyncPipe, StubTranslatePipe] },
+      })
+      .overrideComponent(EditCardDialogComponent, {
+        set: { providers: [{ provide: EditCardDialogFacade, useValue: facadeMock }] },
+      });
+
+    fixture = TestBed.createComponent(EditCardDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    jest.spyOn(component, 'close').mockImplementation(() => undefined);
+  });
+
+  it('resets the facade with the current card when the dialog opens', () => {
+    const card = new CardModel();
+    component.card = card;
+
+    component.ngOnChanges({
+      open: { currentValue: true, previousValue: false, firstChange: false, isFirstChange: () => false },
+    });
+
+    expect(facadeMock.reset).toHaveBeenCalledWith(card);
+  });
+
+  it('resets the facade with undefined when the dialog opens without a card', () => {
+    component.card = undefined;
+
+    component.ngOnChanges({
+      open: { currentValue: true, previousValue: false, firstChange: false, isFirstChange: () => false },
+    });
+
+    expect(facadeMock.reset).toHaveBeenCalledWith(undefined);
+  });
+
+  it('does not reset the facade when a change other than opening occurs', () => {
+    component.ngOnChanges({
+      open: { currentValue: false, previousValue: true, firstChange: false, isFirstChange: () => false },
+    });
+
+    expect(facadeMock.reset).not.toHaveBeenCalled();
+  });
+
+  it('saves the location first for weather cards and stops if it fails', async () => {
+    facadeMock.isWeatherCard = true;
+    facadeMock.saveLocation.mockResolvedValue(false);
+    const editCardSpy = jest.spyOn(component.editCard, 'emit');
+    component.id = 5;
+
+    await component.onSubmit();
+
+    expect(facadeMock.saveLocation).toHaveBeenCalledWith(5);
+    expect(facadeMock.buildSubmitPayload).not.toHaveBeenCalled();
+    expect(component.close).not.toHaveBeenCalled();
+    expect(editCardSpy).not.toHaveBeenCalled();
+  });
+
+  it('builds and emits the payload for weather cards when the location save succeeds', async () => {
+    facadeMock.isWeatherCard = true;
+    facadeMock.saveLocation.mockResolvedValue(true);
+    const payload = new CardModel();
+    facadeMock.buildSubmitPayload.mockReturnValue(payload);
+    const editCardSpy = jest.spyOn(component.editCard, 'emit');
+    component.id = 5;
+
+    await component.onSubmit();
+
+    expect(facadeMock.buildSubmitPayload).toHaveBeenCalledWith(5);
+    expect(component.close).toHaveBeenCalled();
+    expect(editCardSpy).toHaveBeenCalledWith(payload);
+  });
+
+  it('builds and emits the payload directly for non-weather cards', async () => {
+    facadeMock.isWeatherCard = false;
+    const payload = new CardModel();
+    facadeMock.buildSubmitPayload.mockReturnValue(payload);
+    const editCardSpy = jest.spyOn(component.editCard, 'emit');
+    component.id = 9;
+
+    await component.onSubmit();
+
+    expect(facadeMock.saveLocation).not.toHaveBeenCalled();
+    expect(facadeMock.buildSubmitPayload).toHaveBeenCalledWith(9);
+    expect(component.close).toHaveBeenCalled();
+    expect(editCardSpy).toHaveBeenCalledWith(payload);
+  });
+});

--- a/Gridly-Client/src/app/components/dialogs/editCardDialog/edit-card-dialog.facade.spec.ts
+++ b/Gridly-Client/src/app/components/dialogs/editCardDialog/edit-card-dialog.facade.spec.ts
@@ -93,6 +93,14 @@ describe('EditCardDialogFacade', () => {
     expect(facade.card.iconData?.materialIcon).toBe('settings');
   });
 
+  it('resets to a blank card when no initial values are given', () => {
+    facade.card.name = 'Stale';
+
+    facade.reset();
+
+    expect(facade.card.name).toBeUndefined();
+  });
+
   it('resets and builds the submit payload with the card id', () => {
     facade.reset({ name: 'Alpha', url: 'https://alpha.example' });
     const payload = facade.buildSubmitPayload(42);
@@ -145,6 +153,17 @@ describe('EditCardDialogFacade', () => {
       expect(weatherProviderServiceMock.save).toHaveBeenCalled();
       expect(facade.countryInput).toBe('');
       expect(facade.cityInput).toBe('');
+    });
+
+    it('does not re-save when the returned weather already belongs to the requested card', async () => {
+      facade.countryInput = 'Sweden';
+      facade.cityInput = 'Stockholm';
+      weatherProviderServiceMock.getWeather.mockResolvedValue([{ ...makeWeather(), cardId: 9 }, 200]);
+
+      const result = await facade.saveLocation(9);
+
+      expect(result).toBe(false);
+      expect(weatherProviderServiceMock.save).not.toHaveBeenCalled();
     });
 
     it('falls back to getVisualCrossingData and saves the freshly-fetched weather when getWeather fails', async () => {

--- a/Gridly-Client/src/app/components/dialogs/promptDialog/prompt.dialog.component.spec.ts
+++ b/Gridly-Client/src/app/components/dialogs/promptDialog/prompt.dialog.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AsyncPipe } from '@angular/common';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { StubTranslatePipe } from '../../../testing/stub-translate.pipe';
+import { PromptDialogComponent } from './prompt.dialog.component';
+
+describe('PromptDialogComponent', () => {
+  let fixture: ComponentFixture<PromptDialogComponent>;
+  let component: PromptDialogComponent;
+
+  const translateServiceMock = {
+    instant: (key: string) => key,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PromptDialogComponent],
+      providers: [{ provide: TranslateService, useValue: translateServiceMock }],
+    }).overrideComponent(PromptDialogComponent, {
+      remove: { imports: [TranslatePipe] },
+      add: { imports: [AsyncPipe, StubTranslatePipe] },
+    });
+
+    fixture = TestBed.createComponent(PromptDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('closes and emits the card id to remove on submit', () => {
+    jest.spyOn(component, 'close').mockImplementation(() => undefined);
+    const removeSpy = jest.spyOn(component.remove, 'emit');
+    component.id = 7;
+
+    component.onSubmit();
+
+    expect(component.close).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith({ id: 7 });
+  });
+});

--- a/Gridly-Client/src/app/components/dialogs/setLocationForProviderDialog/set-location-for-provider-dialog.component.spec.ts
+++ b/Gridly-Client/src/app/components/dialogs/setLocationForProviderDialog/set-location-for-provider-dialog.component.spec.ts
@@ -1,0 +1,145 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AsyncPipe } from '@angular/common';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { StubTranslatePipe } from '../../../testing/stub-translate.pipe';
+import { WeatherProviderService } from '../../../services/weather_services/weather-provider.service';
+import { ProviderKeysService } from '../../../services/provider_key_services/provider-keys.service';
+import { WeatherDataModel } from '../../../models/weatherData.Model';
+import { SetLocationForProviderDialogComponent } from './set-location-for-provider-dialog.component';
+
+describe('SetLocationForProviderDialogComponent', () => {
+  let fixture: ComponentFixture<SetLocationForProviderDialogComponent>;
+  let component: SetLocationForProviderDialogComponent;
+
+  const weather: WeatherDataModel = {
+    id: 1,
+    cardId: 99,
+    address: 'Sweden,Stockholm',
+    timezone: 'Europe/Stockholm',
+    description: 'Clear',
+    temp: 20,
+    feelsLike: 19,
+    humidity: 50,
+    windSpeed: 5,
+    windDir: 180,
+  };
+
+  const weatherProviderServiceMock = {
+    getWeather: jest.fn(),
+    getVisualCrossingData: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const providerKeysServiceMock = {
+    promptForInvalidKey: jest.fn(),
+  };
+
+  const translateServiceMock = {
+    instant: (key: string) => key,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    TestBed.configureTestingModule({
+      imports: [SetLocationForProviderDialogComponent],
+      providers: [
+        { provide: WeatherProviderService, useValue: weatherProviderServiceMock },
+        { provide: ProviderKeysService, useValue: providerKeysServiceMock },
+        { provide: TranslateService, useValue: translateServiceMock },
+      ],
+    }).overrideComponent(SetLocationForProviderDialogComponent, {
+      remove: { imports: [TranslatePipe] },
+      add: { imports: [AsyncPipe, StubTranslatePipe] },
+    });
+
+    fixture = TestBed.createComponent(SetLocationForProviderDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    jest.spyOn(component, 'close').mockImplementation(() => undefined);
+    component.id = 99;
+  });
+
+  it('does nothing when the country or city input is empty', async () => {
+    component.countryInput = '  ';
+    component.cityInput = 'Stockholm';
+
+    await component.onSubmit();
+
+    expect(weatherProviderServiceMock.getWeather).not.toHaveBeenCalled();
+  });
+
+  it('saves the weather, resets inputs, and closes on a successful lookup', async () => {
+    weatherProviderServiceMock.getWeather.mockResolvedValue([{ ...weather, cardId: 1 }, 200]);
+    component.countryInput = 'Sweden';
+    component.cityInput = 'Stockholm';
+
+    await component.onSubmit();
+
+    expect(weatherProviderServiceMock.getWeather).toHaveBeenCalledWith('Sweden,Stockholm');
+    expect(weatherProviderServiceMock.save).toHaveBeenCalledWith(expect.objectContaining({ cardId: 99 }));
+    expect(component.countryInput).toBe('');
+    expect(component.cityInput).toBe('');
+    expect(component.close).toHaveBeenCalled();
+  });
+
+  it('does not re-save when the weather already belongs to the current card', async () => {
+    weatherProviderServiceMock.getWeather.mockResolvedValue([{ ...weather, cardId: 99 }, 200]);
+    component.countryInput = 'Sweden';
+    component.cityInput = 'Stockholm';
+
+    await component.onSubmit();
+
+    expect(weatherProviderServiceMock.save).not.toHaveBeenCalled();
+    expect(component.close).toHaveBeenCalled();
+  });
+
+  it('falls back to visual crossing and prompts for an invalid key on a 401', async () => {
+    weatherProviderServiceMock.getWeather.mockResolvedValue([undefined, 401]);
+    weatherProviderServiceMock.getVisualCrossingData.mockResolvedValue([undefined, 401]);
+    component.countryInput = 'Sweden';
+    component.cityInput = 'Stockholm';
+
+    await component.onSubmit();
+
+    expect(weatherProviderServiceMock.getVisualCrossingData).toHaveBeenCalledWith('Sweden,Stockholm');
+    expect(providerKeysServiceMock.promptForInvalidKey).toHaveBeenCalled();
+    expect(component.errorMessage).toBe('weatherProviderLocationDialog.text.saveInvalidKeyFailedMessage');
+    expect(component.close).not.toHaveBeenCalled();
+  });
+
+  it('prompts for an invalid key on a 412 from the fallback provider', async () => {
+    weatherProviderServiceMock.getWeather.mockResolvedValue([undefined, 500]);
+    weatherProviderServiceMock.getVisualCrossingData.mockResolvedValue([undefined, 412]);
+    component.countryInput = 'Sweden';
+    component.cityInput = 'Stockholm';
+
+    await component.onSubmit();
+
+    expect(providerKeysServiceMock.promptForInvalidKey).toHaveBeenCalled();
+    expect(component.errorMessage).toBe('weatherProviderLocationDialog.text.saveInvalidKeyFailedMessage');
+  });
+
+  it('sets a not-found error message on a 404', async () => {
+    weatherProviderServiceMock.getWeather.mockResolvedValue([undefined, 404]);
+    weatherProviderServiceMock.getVisualCrossingData.mockResolvedValue([undefined, 404]);
+    component.countryInput = 'Sweden';
+    component.cityInput = 'Stockholm';
+
+    await component.onSubmit();
+
+    expect(providerKeysServiceMock.promptForInvalidKey).not.toHaveBeenCalled();
+    expect(component.errorMessage).toBe('weatherProviderLocationDialog.text.saveLocationNotFoundFailedMessage');
+  });
+
+  it('sets a generic error message for any other failure status', async () => {
+    weatherProviderServiceMock.getWeather.mockResolvedValue([undefined, 500]);
+    weatherProviderServiceMock.getVisualCrossingData.mockResolvedValue([undefined, 500]);
+    component.countryInput = 'Sweden';
+    component.cityInput = 'Stockholm';
+
+    await component.onSubmit();
+
+    expect(component.errorMessage).toBe('weatherProviderLocationDialog.text.saveFailedMessage');
+  });
+});

--- a/Gridly-Client/src/app/components/grid/grid.component.spec.ts
+++ b/Gridly-Client/src/app/components/grid/grid.component.spec.ts
@@ -9,6 +9,7 @@ import { GridComponent } from './grid.component';
 
 type GridComponentTestHarness = GridComponent & {
   drop(event: unknown, rows: RowColumnModel[], rowIndex: number): void;
+  dropToNewRow(event: unknown, rows: RowColumnModel[], rowIndex: number): void;
 };
 
 class MockResizeObserver {
@@ -203,6 +204,33 @@ describe('GridComponent', () => {
         ],
       },
     ]);
+  });
+
+  it('does not insert a new row when edit mode is disabled', () => {
+    editMode.set(false);
+
+    const event = { item: { data: cards[0] } } as never;
+
+    (gridComponent as GridComponentTestHarness).dropToNewRow(event, rows, 1);
+
+    expect(gridServiceMock.setRowsForView).not.toHaveBeenCalled();
+  });
+
+  it('inserts a new row at the given position and removes the card from its source row', () => {
+    const movedCard = { id: 1, indexPosition: 1, rowColumnId: 1, rowPosition: 1, name: 'One', url: 'https://one.example' };
+    const remainingCard = { id: 2, indexPosition: 2, rowColumnId: 1, rowPosition: 1, name: 'Two', url: 'https://two.example' };
+    const rowColumns: RowColumnModel[] = [
+      { id: 1, rowPosition: 1, cards: [movedCard, remainingCard] },
+    ];
+    const event = { item: { data: movedCard } } as never;
+
+    (gridComponent as GridComponentTestHarness).dropToNewRow(event, rowColumns, 1);
+
+    expect(gridServiceMock.normalizeRows).toHaveBeenCalledWith([
+      { id: 0, rowPosition: 1, rowWidth: 0, cards: [movedCard] },
+      { id: 1, rowPosition: 1, cards: [remainingCard] },
+    ]);
+    expect(gridServiceMock.setRowsForView).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the card DOM element stable when a resized card object is emitted', () => {

--- a/Gridly-Client/src/app/components/header/header.component.spec.ts
+++ b/Gridly-Client/src/app/components/header/header.component.spec.ts
@@ -111,4 +111,26 @@ describe('HeaderComponent', () => {
   it('renders the client title', () => {
     expect((fixture.nativeElement as HTMLElement).querySelector('h1')?.textContent).toContain('app.text.title');
   });
+
+  it('opens the add-provider-key dialog', () => {
+    headerComponent.openAddProviderKeyDialog();
+
+    expect(headerComponent.isAddProviderDialogOpen()).toBe(true);
+  });
+
+  it('closes the add-provider-key dialog when the matching dialog id is emitted', () => {
+    headerComponent.openAddProviderKeyDialog();
+
+    (headerComponent as unknown as { handleDialogChange(id: number): void }).handleDialogChange(0);
+
+    expect(headerComponent.isAddProviderDialogOpen()).toBe(false);
+  });
+
+  it('leaves the add-provider-key dialog open when a non-matching dialog id is emitted', () => {
+    headerComponent.openAddProviderKeyDialog();
+
+    (headerComponent as unknown as { handleDialogChange(id: number): void }).handleDialogChange(1);
+
+    expect(headerComponent.isAddProviderDialogOpen()).toBe(true);
+  });
 });

--- a/Gridly-Client/src/app/directives/base-dialog.directive.spec.ts
+++ b/Gridly-Client/src/app/directives/base-dialog.directive.spec.ts
@@ -1,0 +1,101 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AsyncPipe } from '@angular/common';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { StubTranslatePipe } from '../testing/stub-translate.pipe';
+import { DialogService } from '../services/dialog_services/dialog.service';
+import { DeleteCardDialogComponent } from '../components/dialogs/deleteCardDialog/delete-card-dialog.component';
+
+describe('BaseDialogComponent (via DeleteCardDialogComponent)', () => {
+  let fixture: ComponentFixture<DeleteCardDialogComponent>;
+  let component: DeleteCardDialogComponent;
+
+  const dialogServiceMock = {
+    onFileUpload: jest.fn(),
+    resetImageData: jest.fn(),
+  };
+
+  const translateServiceMock = {
+    instant: (key: string) => key,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    TestBed.configureTestingModule({
+      imports: [DeleteCardDialogComponent],
+      providers: [
+        { provide: DialogService, useValue: dialogServiceMock },
+        { provide: TranslateService, useValue: translateServiceMock },
+      ],
+    }).overrideComponent(DeleteCardDialogComponent, {
+      remove: { imports: [TranslatePipe] },
+      add: { imports: [AsyncPipe, StubTranslatePipe] },
+    });
+
+    fixture = TestBed.createComponent(DeleteCardDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('delegates close() to the modal directive when present', () => {
+    const closeSpy = jest.fn();
+    component.modalDirective = { close: closeSpy } as never;
+
+    component.close();
+
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('does not throw when close() is called without a modal directive', () => {
+    component.modalDirective = undefined as never;
+
+    expect(() => component.close()).not.toThrow();
+  });
+
+  it('delegates onBackdropClick() to the modal directive when present', () => {
+    const backdropSpy = jest.fn();
+    component.modalDirective = { onBackdropClick: backdropSpy } as never;
+    const event = new MouseEvent('click');
+
+    component.onBackdropClick(event);
+
+    expect(backdropSpy).toHaveBeenCalledWith(event);
+  });
+
+  it('delegates onFileUpload() to the dialog service', () => {
+    const event = new Event('change');
+    dialogServiceMock.onFileUpload.mockResolvedValue(undefined);
+
+    component.onFileUpload(event);
+
+    expect(dialogServiceMock.onFileUpload).toHaveBeenCalledWith(event);
+  });
+
+  it('delegates resetImageData() to the dialog service', () => {
+    component.resetImageData();
+
+    expect(dialogServiceMock.resetImageData).toHaveBeenCalled();
+  });
+
+  it('reports isOpen based on the modal directive open state', () => {
+    component.modalDirective = { open: true } as never;
+    expect(component.isOpen).toBe(true);
+
+    component.modalDirective = { open: false } as never;
+    expect(component.isOpen).toBe(false);
+  });
+
+  it('reports isOpen as false when there is no modal directive', () => {
+    component.modalDirective = undefined as never;
+    expect(component.isOpen).toBe(false);
+  });
+
+  it('submit() closes the dialog', async () => {
+    const closeSpy = jest.fn();
+    component.modalDirective = { close: closeSpy } as never;
+
+    await component.submit();
+
+    expect(closeSpy).toHaveBeenCalled();
+  });
+});

--- a/Gridly-Client/src/app/directives/dialog.directive.spec.ts
+++ b/Gridly-Client/src/app/directives/dialog.directive.spec.ts
@@ -1,0 +1,118 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DialogDirective } from './dialog.directive';
+
+@Component({
+  standalone: true,
+  imports: [DialogDirective],
+  template: `
+    <dialog appDialogWindow [dialogId]="dialogId" [id]="id" [open]="open" (openChange)="onOpenChange($event)">
+      <button type="button" class="inner-btn">inner</button>
+    </dialog>
+  `,
+})
+class TestHostComponent {
+  @ViewChild(DialogDirective) directive!: DialogDirective;
+  dialogId = 1;
+  id = 1;
+  open = false;
+  lastEmitted: number | undefined;
+
+  onOpenChange(id: number): void {
+    this.lastEmitted = id;
+  }
+}
+
+describe('DialogDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let dialogEl: HTMLDialogElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    dialogEl = fixture.debugElement.query(By.css('dialog')).nativeElement;
+
+    // jsdom does not implement HTMLDialogElement.showModal/close.
+    dialogEl.showModal = jest.fn(() => {
+      Object.defineProperty(dialogEl, 'open', { value: true, configurable: true });
+    });
+    dialogEl.close = jest.fn(() => {
+      Object.defineProperty(dialogEl, 'open', { value: false, configurable: true });
+    });
+
+    fixture.detectChanges();
+  });
+
+  it('opens the native dialog when open becomes true and the ids match', () => {
+    host.open = true;
+    fixture.detectChanges();
+
+    expect(dialogEl.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open the dialog when the dialogId does not match id', () => {
+    host.dialogId = 2;
+    host.open = true;
+    fixture.detectChanges();
+
+    expect(dialogEl.showModal).not.toHaveBeenCalled();
+  });
+
+  it('closes the native dialog when open becomes false while it is open', () => {
+    host.open = true;
+    fixture.detectChanges();
+    (dialogEl.showModal as jest.Mock).mockClear();
+
+    host.open = false;
+    fixture.detectChanges();
+
+    expect(dialogEl.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits openChange with the dialogId when the native close event fires', () => {
+    dialogEl.dispatchEvent(new Event('close'));
+
+    expect(host.lastEmitted).toBe(host.dialogId);
+  });
+
+  it('emits openChange with the dialogId when the native cancel event fires', () => {
+    dialogEl.dispatchEvent(new Event('cancel'));
+
+    expect(host.lastEmitted).toBe(host.dialogId);
+  });
+
+  it('close() calls the native close and emits openChange', () => {
+    host.directive.close();
+
+    expect(dialogEl.close).toHaveBeenCalled();
+    expect(host.lastEmitted).toBe(host.dialogId);
+  });
+
+  it('save() delegates to close()', () => {
+    const closeSpy = jest.spyOn(host.directive, 'close');
+
+    host.directive.save();
+
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('closes when the backdrop itself is clicked', () => {
+    dialogEl.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(dialogEl.close).toHaveBeenCalled();
+  });
+
+  it('does not close when an inner element is clicked', () => {
+    const innerButton = fixture.debugElement.query(By.css('.inner-btn')).nativeElement as HTMLElement;
+
+    innerButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(dialogEl.close).not.toHaveBeenCalled();
+  });
+});

--- a/Gridly-Client/src/app/directives/resizable.directive.spec.ts
+++ b/Gridly-Client/src/app/directives/resizable.directive.spec.ts
@@ -1,0 +1,149 @@
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CardModel } from '../models/card.Model';
+import { ResizableDirective } from './resizable.directive';
+
+@Component({
+  standalone: true,
+  imports: [ResizableDirective],
+  template: `
+    <div class="grid-card-style">
+      <div class="resize-handle" appMakeResizable [canResize]="canResize" [targetCard]="targetCard"></div>
+    </div>
+  `,
+})
+class TestHostComponent {
+  @ViewChild(ResizableDirective) directive!: ResizableDirective;
+  canResize = true;
+  targetCard: CardModel = Object.assign(new CardModel(), {
+    id: 1,
+    indexPosition: 1,
+    name: 'Alpha',
+    url: 'https://alpha.example',
+  });
+}
+
+// jsdom (as used by jest-environment-jsdom) does not implement PointerEvent,
+// so a MouseEvent is used as a stand-in and augmented with a pointerId.
+function pointerEvent(type: string, init: { pointerId: number; clientX?: number; clientY?: number }): Event {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  });
+  Object.defineProperty(event, 'pointerId', { value: init.pointerId, configurable: true });
+  return event;
+}
+
+describe('ResizableDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let handle: HTMLElement;
+  let cardEl: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TestHostComponent] });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    handle = fixture.debugElement.query(By.css('.resize-handle')).nativeElement;
+    cardEl = fixture.debugElement.query(By.css('.grid-card-style')).nativeElement;
+
+    // jsdom does not implement pointer capture.
+    handle.setPointerCapture = jest.fn();
+    handle.releasePointerCapture = jest.fn();
+  });
+
+  afterEach(() => {
+    document.body.removeAttribute('style');
+  });
+
+  it('does nothing on pointerdown when canResize is false', () => {
+    host.canResize = false;
+    fixture.detectChanges();
+
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+
+    expect(handle.setPointerCapture).not.toHaveBeenCalled();
+  });
+
+  it('captures the pointer and hides the cursor on pointerdown', () => {
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+
+    expect(handle.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(document.body.style.cursor).toBe('none');
+  });
+
+  it('falls back to walking up parentElement when closest() cannot find the card', () => {
+    handle.closest = jest.fn(() => null);
+
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+
+    expect(handle.setPointerCapture).toHaveBeenCalledWith(1);
+  });
+
+  it('does nothing on pointerdown when no .grid-card-style ancestor exists', () => {
+    cardEl.classList.remove('grid-card-style');
+
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+
+    expect(handle.setPointerCapture).not.toHaveBeenCalled();
+  });
+
+  it('ignores pointermove events when no drag has started', () => {
+    document.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: 500, clientY: 500 }));
+
+    expect(cardEl.style.width).toBe('');
+  });
+
+  it('ignores pointermove events from a different pointer than the one that started the drag', () => {
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+
+    document.dispatchEvent(pointerEvent('pointermove', { pointerId: 2, clientX: 500, clientY: 500 }));
+
+    expect(cardEl.style.width).toBe('');
+  });
+
+  it.each([
+    [0, 250],
+    [150, 300],
+    [350, 500],
+    [550, 700],
+    [700, 800],
+  ])('snaps the card size to the nearest breakpoint (deltaX=%d -> %dpx)', (deltaX, expectedSize) => {
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+    document.dispatchEvent(pointerEvent('pointermove', { pointerId: 1, clientX: deltaX, clientY: 0 }));
+
+    expect(host.targetCard.settings?.width).toBe(expectedSize);
+    expect(host.targetCard.settings?.height).toBe(250);
+    expect(cardEl.style.width).toBe(`${expectedSize}px`);
+    expect(cardEl.style.flex).toBe(`0 0 ${expectedSize}px`);
+  });
+
+  it('releases the pointer and restores the cursor on pointerup', () => {
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+
+    document.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }));
+
+    expect(handle.releasePointerCapture).toHaveBeenCalledWith(1);
+    expect(document.body.style.cursor).toBe('auto');
+  });
+
+  it('releases the pointer and restores the cursor on pointercancel', () => {
+    handle.dispatchEvent(pointerEvent('pointerdown', { pointerId: 1, clientX: 0, clientY: 0 }));
+
+    document.dispatchEvent(pointerEvent('pointercancel', { pointerId: 1 }));
+
+    expect(handle.releasePointerCapture).toHaveBeenCalledWith(1);
+    expect(document.body.style.cursor).toBe('auto');
+  });
+
+  it('ignores pointerup when no drag is in progress', () => {
+    document.dispatchEvent(pointerEvent('pointerup', { pointerId: 1 }));
+
+    expect(handle.releasePointerCapture).not.toHaveBeenCalled();
+  });
+});

--- a/Gridly-Client/src/app/services/card_services/card.service.spec.ts
+++ b/Gridly-Client/src/app/services/card_services/card.service.spec.ts
@@ -74,6 +74,15 @@ describe('CardService', () => {
     ]);
   });
 
+  it('sorts multiple row groups by their row position', () => {
+    const rowTwoCard: CardModel = { ...cardA, rowPosition: 2 };
+    const rowOneCard: CardModel = { ...cardB, rowPosition: 1 };
+
+    const rows = service.toRows([rowTwoCard, rowOneCard], 1000);
+
+    expect(rows.map((row) => row.map((card) => card.id))).toEqual([[cardB.id], [cardA.id]]);
+  });
+
   it('keeps cards from the same API row horizontal', () => {
     const rows = service.toRows([cardB, cardA], 1000);
 

--- a/Gridly-Client/src/app/services/dialog_services/dialog.service.spec.ts
+++ b/Gridly-Client/src/app/services/dialog_services/dialog.service.spec.ts
@@ -59,4 +59,78 @@ describe('DialogService', () => {
 
     expect(readFileAsBase64Spy).toHaveBeenCalledWith(file);
   });
+
+  it('accepts a supported image extension even without an image/* mime type', async () => {
+    const file = new File(['<svg></svg>'], 'weather.svg', { type: 'application/octet-stream' });
+    const event = {
+      target: { files: { item: () => file } },
+    } as unknown as Event;
+
+    const result = await service.onFileUpload(event);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('svg');
+  });
+
+  it('keeps the whole file name when it has no extension', async () => {
+    const file = new File(['data'], 'noextension', { type: 'image/png' });
+    const event = {
+      target: { files: { item: () => file } },
+    } as unknown as Event;
+
+    const result = await service.onFileUpload(event);
+
+    expect(result?.name).toBe('noextension');
+  });
+
+  it('returns default settings', () => {
+    expect(service.settings()).toEqual({
+      width: 250,
+      height: 250,
+      imageHidden: false,
+      titleHidden: false,
+    });
+  });
+
+  it('builds icon data for a given material icon name', () => {
+    expect(service.setIcon('box')).toEqual({
+      id: undefined,
+      type: '',
+      name: '',
+      base64Data: '',
+      materialIcon: 'box',
+    });
+  });
+
+  it('toggles the add-provider-key dialog open and closed', () => {
+    service.openProviderKeyDialog(5);
+    expect(service.isAddProviderDialogOpen()).toBe(5);
+
+    service.closeAddProviderKeyDialog();
+    expect(service.isAddProviderDialogOpen()).toBeNull();
+  });
+
+  it('toggles the set-provider-location dialog open and closed', () => {
+    service.openSetProviderLocationDialog(6);
+    expect(service.isSetProviderLocationDialogOpen()).toBe(6);
+
+    service.closeSetProviderLocationDialog();
+    expect(service.isSetProviderLocationDialogOpen()).toBeNull();
+  });
+
+  it('toggles the edit-card dialog open and closed', () => {
+    service.openEditDialog(7);
+    expect(service.isEditDialogOpen()).toBe(7);
+
+    service.closeEditDialog();
+    expect(service.isEditDialogOpen()).toBeNull();
+  });
+
+  it('toggles the delete-card dialog open and closed', () => {
+    service.openDeleteDialog(8);
+    expect(service.isDeleteDialogOpen()).toBe(8);
+
+    service.closeDeleteDialog();
+    expect(service.isDeleteDialogOpen()).toBeNull();
+  });
 });

--- a/Gridly-Client/src/app/services/endpoint_services/card.endpoint.service.spec.ts
+++ b/Gridly-Client/src/app/services/endpoint_services/card.endpoint.service.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { urlConstants } from '../../constants/url.constants';
+import { CardModel } from '../../models/card.Model';
+import { CardEndpointService } from './card.endpoint.service';
+
+describe('CardEndpointService', () => {
+  let service: CardEndpointService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(CardEndpointService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends a GET request to the card endpoint and returns the response', () => {
+    const cards: CardModel[] = [
+      { id: 1, indexPosition: 1, rowPosition: 1, name: 'Alpha', url: 'https://alpha.example' },
+    ];
+    let result: CardModel[] | undefined;
+
+    service.get().subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(urlConstants.card.get);
+    expect(req.request.method).toBe('GET');
+    req.flush(cards);
+
+    expect(result).toEqual(cards);
+  });
+});

--- a/Gridly-Client/src/app/services/endpoint_services/icon.endpoint.service.spec.ts
+++ b/Gridly-Client/src/app/services/endpoint_services/icon.endpoint.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { urlConstants } from '../../constants/url.constants';
+import { IconModel } from '../../models/icon.Model';
+import { SearchIconsResultDto } from '../../dtos/searchIconsResultDto';
+import { IconEndpointService } from './icon.endpoint.service';
+
+describe('IconEndpointService', () => {
+  let service: IconEndpointService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(IconEndpointService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends a GET request to the icon endpoint and returns the response', () => {
+    const icon: IconModel = { type: 'svg', name: 'dashboard', base64Data: 'abc', materialIcon: 'dashboard' };
+    let result: IconModel | undefined;
+
+    service.get().subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(urlConstants.icon.get);
+    expect(req.request.method).toBe('GET');
+    req.flush(icon);
+
+    expect(result).toEqual(icon);
+  });
+
+  it('sends a GET request to the icon search endpoint with the search input appended to the URL', () => {
+    const dto: SearchIconsResultDto = { icons: ['box', 'grid'] };
+    let result: SearchIconsResultDto | undefined;
+
+    service.search('box').subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(`${urlConstants.icon.search}box`);
+    expect(req.request.method).toBe('GET');
+    req.flush(dto);
+
+    expect(result).toEqual(dto);
+  });
+});

--- a/Gridly-Client/src/app/services/endpoint_services/provider-keys.endpoint.service.spec.ts
+++ b/Gridly-Client/src/app/services/endpoint_services/provider-keys.endpoint.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { urlConstants } from '../../constants/url.constants';
+import { ProviderKeyStatusModel } from '../../models/providerKeyStatus.Model';
+import { ProviderKeyStatus } from '../../enums/provider-key-status.enum';
+import { ThirdPartyProvider } from '../../enums/third-party-provider.enum';
+import { ProviderKeysEndpointService } from './provider-keys.endpoint.service';
+
+describe('ProviderKeysEndpointService', () => {
+  let service: ProviderKeysEndpointService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ProviderKeysEndpointService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends a GET request for the local provider key status with the provider as a param', () => {
+    const status: ProviderKeyStatusModel = { exists: true, keyStatus: ProviderKeyStatus.Valid };
+    let result: ProviderKeyStatusModel | undefined;
+
+    service.getLocalProviderStatus(ThirdPartyProvider.VisualCrossing).subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(
+      (r) => r.url === urlConstants.providerKey.getLocalStatus && r.params.get('Provider') === ThirdPartyProvider.VisualCrossing
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(status);
+
+    expect(result).toEqual(status);
+  });
+
+  it('sends a GET request for the remote provider key status with the provider as a param', () => {
+    const status: ProviderKeyStatusModel = { exists: false, keyStatus: ProviderKeyStatus.Unknown };
+    let result: ProviderKeyStatusModel | undefined;
+
+    service.getRemoteProviderStatus(ThirdPartyProvider.VisualCrossing).subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(
+      (r) => r.url === urlConstants.providerKey.getRemoteStatus && r.params.get('Provider') === ThirdPartyProvider.VisualCrossing
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(status);
+
+    expect(result).toEqual(status);
+  });
+
+  it('sends a POST request to save the provider key with the provider and raw key as the body', () => {
+    let completed = false;
+
+    service.save(ThirdPartyProvider.VisualCrossing, 'raw-key').subscribe(() => (completed = true));
+
+    const req = httpMock.expectOne(urlConstants.providerKey.save);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ provider: ThirdPartyProvider.VisualCrossing, rawKey: 'raw-key' });
+    req.flush(null);
+
+    expect(completed).toBe(true);
+  });
+});

--- a/Gridly-Client/src/app/services/endpoint_services/rowColumn.endpoint.service.spec.ts
+++ b/Gridly-Client/src/app/services/endpoint_services/rowColumn.endpoint.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { urlConstants } from '../../constants/url.constants';
+import { RowColumnModel } from '../../models/rowColumn.Model';
+import { RowColumnEndpointService } from './rowColumn.endpoint.service';
+
+describe('RowColumnEndpointService', () => {
+  let service: RowColumnEndpointService;
+  let httpMock: HttpTestingController;
+
+  const row: RowColumnModel = { id: 1, cards: [], rowPosition: 1, rowWidth: 1000 };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(RowColumnEndpointService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends a GET request to the row endpoint and returns the response', () => {
+    let result: RowColumnModel[] | null | undefined;
+
+    service.get().subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(urlConstants.rowColumn.get);
+    expect(req.request.method).toBe('GET');
+    req.flush([row]);
+
+    expect(result).toEqual([row]);
+  });
+
+  it('sends a POST request with the rows to batch save, and returns the saved rows', () => {
+    let result: RowColumnModel[] | undefined;
+
+    service.batchSave([row]).subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(urlConstants.rowColumn.batchSave);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual([row]);
+    req.flush([row]);
+
+    expect(result).toEqual([row]);
+  });
+});

--- a/Gridly-Client/src/app/services/endpoint_services/version.endpoint.service.spec.ts
+++ b/Gridly-Client/src/app/services/endpoint_services/version.endpoint.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { urlConstants } from '../../constants/url.constants';
+import { VersionModel } from '../../models/version.Model';
+import { VersionEndpointService } from './version.endpoint.service';
+
+describe('VersionEndpointService', () => {
+  let service: VersionEndpointService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(VersionEndpointService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends a GET request to the version endpoint and returns the response', () => {
+    const version: VersionModel = { name: 'v1.2.3', newRelease: false };
+    let result: VersionModel | undefined;
+
+    service.get().subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(urlConstants.version.get);
+    expect(req.request.method).toBe('GET');
+    req.flush(version);
+
+    expect(result).toEqual(version);
+  });
+});

--- a/Gridly-Client/src/app/services/endpoint_services/weather.endpoint.service.spec.ts
+++ b/Gridly-Client/src/app/services/endpoint_services/weather.endpoint.service.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { urlConstants } from '../../constants/url.constants';
+import { WeatherDataModel } from '../../models/weatherData.Model';
+import { WeatherEndpointService } from './weather.endpoint.service';
+
+describe('WeatherEndpointService', () => {
+  let service: WeatherEndpointService;
+  let httpMock: HttpTestingController;
+
+  const weather: WeatherDataModel = {
+    id: 1,
+    cardId: 1,
+    address: 'Sweden,Stockholm',
+    timezone: 'Europe/Stockholm',
+    description: 'Clear',
+    temp: 20,
+    feelsLike: 19,
+    humidity: 50,
+    windSpeed: 5,
+    windDir: 180,
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(WeatherEndpointService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends a GET request to the weather endpoint with the address as a param', () => {
+    let result: WeatherDataModel | undefined;
+
+    service.get('Sweden,Stockholm').subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(
+      (r) => r.url === urlConstants.weather.get && r.params.get('Address') === 'Sweden,Stockholm'
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(weather);
+
+    expect(result).toEqual(weather);
+  });
+
+  it('sends a GET request to fetch stored weather data', () => {
+    let result: WeatherDataModel[] | undefined;
+
+    service.getStoredWeatherData().subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(urlConstants.weather.getStoredWeatherData);
+    expect(req.request.method).toBe('GET');
+    req.flush([weather]);
+
+    expect(result).toEqual([weather]);
+  });
+
+  it('sends a GET request to the visual crossing endpoint with the address as a param', () => {
+    let result: WeatherDataModel | undefined;
+
+    service.getvisualcrossingdata('Sweden,Stockholm').subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(
+      (r) => r.url === urlConstants.weather.getVisualCrossingData && r.params.get('Address') === 'Sweden,Stockholm'
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(weather);
+
+    expect(result).toEqual(weather);
+  });
+
+  it('sends a POST request to save weather data with the weather wrapped in the body', () => {
+    let completed = false;
+
+    service.save(weather).subscribe(() => (completed = true));
+
+    const req = httpMock.expectOne(urlConstants.weather.save);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ weather });
+    req.flush(null);
+
+    expect(completed).toBe(true);
+  });
+});

--- a/Gridly-Client/src/app/services/endpoint_services/widget.endpoint.service.spec.ts
+++ b/Gridly-Client/src/app/services/endpoint_services/widget.endpoint.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { urlConstants } from '../../constants/url.constants';
+import { Widget } from '../../interfaces/widget.Interface';
+import { WidgetEndpointService } from './widget.endpoint.service';
+
+describe('WidgetEndpointService', () => {
+  let service: WidgetEndpointService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(WidgetEndpointService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends a GET request to the widget endpoint and returns the response', () => {
+    const widgets: Widget[] = [{ id: 1, widgetType: 'Empty', label: 'Empty', description: '', icon: '' }];
+    let result: Widget[] | undefined;
+
+    service.get().subscribe((res) => (result = res));
+
+    const req = httpMock.expectOne(urlConstants.widget.get);
+    expect(req.request.method).toBe('GET');
+    req.flush(widgets);
+
+    expect(result).toEqual(widgets);
+  });
+});

--- a/Gridly-Client/src/app/services/grid_services/grid.service.spec.ts
+++ b/Gridly-Client/src/app/services/grid_services/grid.service.spec.ts
@@ -128,6 +128,36 @@ describe('GridService', () => {
     ]);
   });
 
+  it('toggles edit mode', () => {
+    expect(service.inEditMode()).toBe(false);
+
+    service.toggleEdit();
+    expect(service.inEditMode()).toBe(true);
+
+    service.toggleEdit();
+    expect(service.inEditMode()).toBe(false);
+  });
+
+  it('updates a card in place and renumbers the row it belongs to', () => {
+    const firstCard = createCard(1);
+    const targetCard = createCard(2);
+    service.setRowsForView([{ id: 1, rowPosition: 1, cards: [firstCard, targetCard] }]);
+
+    service.updateCardInView(targetCard, { ...targetCard, name: 'Renamed' });
+
+    expect(service.currentRowColumns()).toEqual([
+      {
+        id: 1,
+        rowPosition: 1,
+        rowWidth: 0,
+        cards: [
+          { ...firstCard, indexPosition: 1, rowPosition: 1, rowColumnId: 1 },
+          { ...targetCard, name: 'Renamed', indexPosition: 2, rowPosition: 1, rowColumnId: 1 },
+        ],
+      },
+    ]);
+  });
+
   it('saves normalized rows through the row batchSave endpoint', async () => {
     const card = createCard(1);
     service.setRowsForView([{ id: 1, rowPosition: 1, cards: [card] }]);

--- a/Gridly-Client/src/app/services/provider_key_services/provider-keys.service.spec.ts
+++ b/Gridly-Client/src/app/services/provider_key_services/provider-keys.service.spec.ts
@@ -56,4 +56,33 @@ describe('ProviderKeysService', () => {
     expect(endpointMock.getRemoteProviderStatus).toHaveBeenCalledWith(ThirdPartyProvider.VisualCrossing);
     expect(service.currentStatus()).toEqual({ exists: true, status: ProviderKeyStatus.Valid });
   });
+
+  it('saves a key for the given provider', () => {
+    endpointMock.getLocalProviderStatus.mockReturnValue(EMPTY);
+    endpointMock.save.mockReturnValue(of(undefined));
+    const service = createService();
+
+    service.save('raw-key', ThirdPartyProvider.VisualCrossing);
+
+    expect(endpointMock.save).toHaveBeenCalledWith(ThirdPartyProvider.VisualCrossing, 'raw-key');
+  });
+
+  it('saves a key for the default provider when none is given', () => {
+    endpointMock.getLocalProviderStatus.mockReturnValue(EMPTY);
+    endpointMock.save.mockReturnValue(of(undefined));
+    const service = createService();
+
+    service.save('raw-key');
+
+    expect(endpointMock.save).toHaveBeenCalledWith(ThirdPartyProvider.VisualCrossing, 'raw-key');
+  });
+
+  it('flags that the user should be prompted for a key', () => {
+    endpointMock.getLocalProviderStatus.mockReturnValue(EMPTY);
+    const service = createService();
+
+    service.promptForInvalidKey();
+
+    expect(service.shouldPromptForKey()).toBe(true);
+  });
 });

--- a/Gridly-Client/src/app/services/weather_services/weather-provider.service.spec.ts
+++ b/Gridly-Client/src/app/services/weather_services/weather-provider.service.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { WeatherEndpointService } from '../endpoint_services/weather.endpoint.service';
+import { WeatherDataModel } from '../../models/weatherData.Model';
+import { WeatherProviderService } from './weather-provider.service';
+
+describe('WeatherProviderService', () => {
+  let service: WeatherProviderService;
+
+  const weather: WeatherDataModel = {
+    id: 1,
+    cardId: 1,
+    address: 'Sweden,Stockholm',
+    timezone: 'Europe/Stockholm',
+    description: 'Clear',
+    temp: 20,
+    feelsLike: 19,
+    humidity: 50,
+    windSpeed: 5,
+    windDir: 180,
+  };
+
+  const endpointMock = {
+    save: jest.fn(),
+    get: jest.fn(),
+    getStoredWeatherData: jest.fn(),
+    getvisualcrossingdata: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    endpointMock.getStoredWeatherData.mockReturnValue(of([weather]));
+
+    TestBed.configureTestingModule({
+      providers: [
+        WeatherProviderService,
+        { provide: WeatherEndpointService, useValue: endpointMock },
+      ],
+    });
+
+    service = TestBed.inject(WeatherProviderService);
+  });
+
+  it('loads stored weather data on construction', () => {
+    expect(endpointMock.getStoredWeatherData).toHaveBeenCalledTimes(1);
+    expect(service.storedWeatherData()).toEqual([weather]);
+  });
+
+  it('refreshes the stored weather data stream on demand', () => {
+    endpointMock.getStoredWeatherData.mockReturnValue(of([]));
+
+    service.refresh();
+
+    expect(endpointMock.getStoredWeatherData).toHaveBeenCalledTimes(2);
+    expect(service.storedWeatherData()).toEqual([]);
+  });
+
+  it('saves weather data through the endpoint', async () => {
+    endpointMock.save.mockReturnValue(of(undefined));
+
+    await service.save(weather);
+
+    expect(endpointMock.save).toHaveBeenCalledWith(weather);
+  });
+
+  it('returns weather data with a 200 status on a successful getWeather call', async () => {
+    endpointMock.get.mockReturnValue(of(weather));
+
+    const [result, status] = await service.getWeather('Sweden,Stockholm');
+
+    expect(result).toEqual(weather);
+    expect(status).toBe(200);
+  });
+
+  it('returns undefined and the http status when getWeather fails with an HttpErrorResponse', async () => {
+    endpointMock.get.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    const [result, status] = await service.getWeather('Sweden,Stockholm');
+
+    expect(result).toBeUndefined();
+    expect(status).toBe(404);
+  });
+
+  it('returns status 0 when getWeather fails with a non-http error', async () => {
+    endpointMock.get.mockReturnValue(throwError(() => new Error('boom')));
+
+    const [result, status] = await service.getWeather('Sweden,Stockholm');
+
+    expect(result).toBeUndefined();
+    expect(status).toBe(0);
+  });
+
+  it('returns weather data with a 200 status on a successful getVisualCrossingData call', async () => {
+    endpointMock.getvisualcrossingdata.mockReturnValue(of(weather));
+
+    const [result, status] = await service.getVisualCrossingData('Sweden,Stockholm');
+
+    expect(result).toEqual(weather);
+    expect(status).toBe(200);
+  });
+
+  it('returns undefined and the http status when getVisualCrossingData fails with an HttpErrorResponse', async () => {
+    endpointMock.getvisualcrossingdata.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 401 })));
+
+    const [result, status] = await service.getVisualCrossingData('Sweden,Stockholm');
+
+    expect(result).toBeUndefined();
+    expect(status).toBe(401);
+  });
+});

--- a/Gridly-Client/src/app/services/widget_services/widget.service.spec.ts
+++ b/Gridly-Client/src/app/services/widget_services/widget.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { WidgetEndpointService } from '../endpoint_services/widget.endpoint.service';
+import { Widget } from '../../interfaces/widget.Interface';
+import { WidgetService } from './widget.service';
+
+describe('WidgetService', () => {
+  let service: WidgetService;
+
+  const widgets: Widget[] = [{ id: 1, widgetType: 'Empty', label: 'Empty', description: '', icon: '' }];
+
+  const endpointMock = {
+    get: jest.fn(() => of(widgets)),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    endpointMock.get.mockReturnValue(of(widgets));
+
+    TestBed.configureTestingModule({
+      providers: [
+        WidgetService,
+        { provide: WidgetEndpointService, useValue: endpointMock },
+      ],
+    });
+
+    service = TestBed.inject(WidgetService);
+  });
+
+  it('resolves the widgets from the endpoint service', async () => {
+    const result = await service.get();
+
+    expect(endpointMock.get).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(widgets);
+  });
+});


### PR DESCRIPTION
Add specs for all previously untested endpoint services, dialog components and directives, mocking HTTP calls via
HttpClientTestingModule instead of hitting the real API. Strengthen a handful of existing specs to close branch-coverage gaps. Wire up --coverage in the npm script and CI workflow, add an 80% coverage threshold to jest.config.js, ignore the generated coverage folder, and document the frontend testing standard in AGENTS.md.


Claude-Session: https://claude.ai/code/session_01Seb4UNi5e1cbYCKeg3QUXM