### PR TITLE
Eliminate all dotnet build/test warnings (#338)

### DIFF
--- a/CQRS/Commands/SaveProviderKeyCommand.cs
+++ b/CQRS/Commands/SaveProviderKeyCommand.cs
@@ -4,6 +4,6 @@ namespace Gridly.Commands;
 
 public class SaveProviderKeyCommand : IRequest<IResult>
 {
-    public string Provider { get; set; }
-    public string RawKey { get; set; }
+    public required string Provider { get; set; }
+    public required string RawKey { get; set; }
 }

--- a/CQRS/Commands/SaveWeatherCommand.cs
+++ b/CQRS/Commands/SaveWeatherCommand.cs
@@ -5,6 +5,6 @@ namespace Gridly.Commands;
 
 public class SaveWeatherCommand : IRequest<IResult>
 {
-    public WeatherDataModel Weather { get; set; }
+    public required WeatherDataModel Weather { get; set; }
     public int CardId { get; set; }
 }

--- a/CQRS/Querys/GetIconQuery.cs
+++ b/CQRS/Querys/GetIconQuery.cs
@@ -1,5 +1,4 @@
-using Gridly.Models;
 using MediatR;
 
 namespace Gridly.Querys;
-public class GetIconQuery : IconModel, IRequest<IResult> {}
+public class GetIconQuery : IRequest<IResult> {}

--- a/CQRS/Querys/GetLatestVersionQuery.cs
+++ b/CQRS/Querys/GetLatestVersionQuery.cs
@@ -1,6 +1,5 @@
-using Gridly.Models;
 using MediatR;
 
 namespace Gridly.Querys;
 
-public class GetLatestVersionQuery : VersionModel, IRequest<IResult> {}
+public class GetLatestVersionQuery : IRequest<IResult> {}

--- a/CQRS/Querys/GetLocalProviderKeyStatusQuery.cs
+++ b/CQRS/Querys/GetLocalProviderKeyStatusQuery.cs
@@ -4,5 +4,5 @@ namespace Gridly.Querys;
 
 public class GetLocalProviderKeyStatusQuery : IRequest<IResult>
 {
-    public string Provider { get; set; }
+    public required string Provider { get; set; }
 }

--- a/CQRS/Querys/GetRemoteProviderKeyStatusQuery.cs
+++ b/CQRS/Querys/GetRemoteProviderKeyStatusQuery.cs
@@ -4,5 +4,5 @@ namespace Gridly.Querys;
 
 public class GetRemoteProviderKeyStatusQuery : IRequest<IResult>
 {
-    public string Provider { get; set; }
+    public required string Provider { get; set; }
 }

--- a/CQRS/Querys/GetVersionQuery.cs
+++ b/CQRS/Querys/GetVersionQuery.cs
@@ -1,6 +1,5 @@
-using Gridly.Models;
 using MediatR;
 
 namespace Gridly.Querys;
 
-public class GetVersionQuery : VersionModel, IRequest<IResult> {}
+public class GetVersionQuery : IRequest<IResult> {}

--- a/CQRS/Querys/GetVisualCrossingDataQuery.cs
+++ b/CQRS/Querys/GetVisualCrossingDataQuery.cs
@@ -4,5 +4,5 @@ namespace Gridly.Querys;
 
 public class GetVisualCrossingDataQuery : IRequest<IResult>
 {
-    public string Address { get; set; }
+    public required string Address { get; set; }
 }

--- a/CQRS/Querys/GetWeatherQuery.cs
+++ b/CQRS/Querys/GetWeatherQuery.cs
@@ -4,5 +4,5 @@ namespace Gridly.Querys;
 
 public class GetWeatherQuery : IRequest<IResult>
 {
-    public string Address { get; set; }
+    public required string Address { get; set; }
 }

--- a/CQRS/Querys/SearchIconsQuery.cs
+++ b/CQRS/Querys/SearchIconsQuery.cs
@@ -4,5 +4,5 @@ namespace Gridly.Querys;
 
 public class SearchIconsQuery : IRequest<IResult> 
 {
-    public string SearchTerm { get; set; }
+    public required string SearchTerm { get; set; }
 }

--- a/Data/DbCommandRunner.cs
+++ b/Data/DbCommandRunner.cs
@@ -13,7 +13,7 @@ public class DbCommandRunner
         _connection = connection;                                
     }                                                            
     
-    public async Task<bool> Execute<T>(string query,IEnumerable<T> parameters)
+    public async Task<bool> Execute<T>(string query,IEnumerable<T>? parameters)
     {
         _connection.Open();
         using var tx = _connection.BeginTransaction();
@@ -22,35 +22,35 @@ public class DbCommandRunner
         _connection.Close();
         return _rowsEffected > 0;
     }
-    
+
     public async Task<T> Execute<T>(string query,T parameters)
     {
         _connection.Open();
         var item = await _connection.QueryFirstOrDefaultAsync<T>(query, parameters);
         _connection.Close();
-        return item;
+        return item!;
     }
-    public async Task<bool> Execute(string query,object parameters)
+    public async Task<bool> Execute(string query,object? parameters)
     {
         _connection.Open();
         var rowsEffected = await _connection.ExecuteAsync(query, parameters);
         _connection.Close();
         return rowsEffected > 0;
     }
-    
-    public async Task<IEnumerable<T>> SelectMany<T>(string query,object parameters)
+
+    public async Task<IEnumerable<T>> SelectMany<T>(string query,object? parameters)
     {
-        _connection.Open();                                             
+        _connection.Open();
         var items = await _connection.QueryAsync<T>(query, parameters);
         _connection.Close();
         return items;
     }
-    
-    public async Task<T> Select<T>(string query,object parameters)
+
+    public async Task<T> Select<T>(string query,object? parameters)
     {
-        _connection.Open();                                             
+        _connection.Open();
         var items = await _connection.QueryFirstOrDefaultAsync<T>(query, parameters);
         _connection.Close();
-        return items;
+        return items!;
     }
 }

--- a/Dtos/CardDtoModel.cs
+++ b/Dtos/CardDtoModel.cs
@@ -5,15 +5,15 @@ public class CardDtoModel
     public int CardId { get; set; }
     public int IndexPosition { get; set; }
     public int RowColumnId { get; set; }
-    public string CardName { get; set; }
-    public string CardType { get; set; }
-    public string Url { get; set; }
-    public string IconUrl { get; set; }
+    public required string CardName { get; set; }
+    public required string CardType { get; set; }
+    public required string Url { get; set; }
+    public required string IconUrl { get; set; }
     public int IconId { get; set; }
-    public string IconName { get; set; }
-    public string Type { get; set; }
-    public string Base64Data { get; set; }
-    public string MaterialIcon { get; set; }
+    public required string IconName { get; set; }
+    public required string Type { get; set; }
+    public required string Base64Data { get; set; }
+    public required string MaterialIcon { get; set; }
     public int SettingsId { get; set; }
     public int Width { get; set; }
     public int Height { get; set; }

--- a/Dtos/ColumnRowDtoModel.cs
+++ b/Dtos/ColumnRowDtoModel.cs
@@ -6,6 +6,6 @@ public class ColumnRowDtoModel
 {
     public int Id { get; set; }
     public int RowPosition { get; set; }
-    public IEnumerable<CardModel> Cards { get; set; }
+    public required IEnumerable<CardModel> Cards { get; set; }
     public int RowWidth { get; set; }
 }

--- a/Dtos/ProviderKeyDtoModel.cs
+++ b/Dtos/ProviderKeyDtoModel.cs
@@ -3,8 +3,8 @@ namespace Gridly.Dtos;
 public class ProviderKeyDtoModel
 {
     public int Id { get; set; }
-    public string Provider { get; set; }
-    public string EncryptedKey { get; set; }
-    public string Status { get; set; }
+    public required string Provider { get; set; }
+    public required string EncryptedKey { get; set; }
+    public required string Status { get; set; }
     public DateTime? LastValidatedAt { get; set; }
 }

--- a/Dtos/SearchIconsResultDto.cs
+++ b/Dtos/SearchIconsResultDto.cs
@@ -2,6 +2,6 @@
 {
     public class SearchIconsResultDto
     {
-        public string[] Icons { get; set; }
+        public required string[] Icons { get; set; }
     }
 }

--- a/Dtos/StoredWeatherDataDto.cs
+++ b/Dtos/StoredWeatherDataDto.cs
@@ -4,9 +4,9 @@ public class StoredWeatherDataDto
 {
     public int Id { get; set; }
     public int CardId { get; set; }
-    public string Address { get; set; }
-    public string Timezone { get; set; }
-    public string Description { get; set; }
+    public required string Address { get; set; }
+    public required string Timezone { get; set; }
+    public required string Description { get; set; }
     public double Temp { get; set; }
     public double FeelsLike { get; set; }
     public double Humidity { get; set; }

--- a/Dtos/WidgetDtoModel.cs
+++ b/Dtos/WidgetDtoModel.cs
@@ -3,8 +3,8 @@ namespace Gridly.Dtos;
 public class WidgetDtoModel
 {
     public int Id {get; set;}
-    public string WidgetType {get; set;}
-    public string Label {get; set;}
-    public string Description {get; set;}
-    public string Icon {get; set;}
+    public required string WidgetType {get; set;}
+    public required string Label {get; set;}
+    public required string Description {get; set;}
+    public required string Icon {get; set;}
 }

--- a/EndPoints/VersionEndPoint.cs
+++ b/EndPoints/VersionEndPoint.cs
@@ -10,7 +10,7 @@ public class VersionEndPoint(
 {
     public async Task<(bool, VersionModel?)> GetLatestVersion()
     {
-        VersionModel version = null;
+        VersionModel? version = null;
         var (success,item) = await httpClientServices.Get(EndpointStrings.GetVersionRemoteEndPoint);
         if (success) version = dataConverter.DeserializeJson(item);
         return (success, version);
@@ -18,7 +18,7 @@ public class VersionEndPoint(
 
     public async Task<(bool, VersionModel?)> GetVersion()
     {
-        VersionModel version = null;
+        VersionModel? version = null;
        var (success,item) = await httpClientServices.Get(EndpointStrings.GetVersionInternalEndPoint);
        if (success) version = dataConverter.DeserializeJson(item);
        return (success, version);

--- a/Factories/ColumnRowFactory.cs
+++ b/Factories/ColumnRowFactory.cs
@@ -10,7 +10,8 @@ public static class ColumnRowFactory
         {
             Id = dto.Id,
             RowPosition = dto. RowPosition,
-            RowWidth = dto.RowWidth 
+            RowWidth = dto.RowWidth,
+            Cards = []
         };
 
     public static IEnumerable<ColumnRowModel> CreateMany(IEnumerable<ColumnRowDtoModel> dtos) 

--- a/Gridly.csproj
+++ b/Gridly.csproj
@@ -7,6 +7,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <IsTestProject>true</IsTestProject>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,7 +33,6 @@
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.1.25080.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
@@ -40,6 +41,11 @@
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
-  
-  
+
+  <!-- No patched SQLitePCLRaw.lib.e_sqlite3 exists yet for this advisory (tracked upstream in
+       dotnet/dotnet#7294); remove this suppression once Microsoft.Data.Sqlite ships a fix. -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
 </Project>

--- a/Handlers/CardHandler.cs
+++ b/Handlers/CardHandler.cs
@@ -1,3 +1,4 @@
+using Gridly.Models;
 using Gridly.Querys;
 using Gridly.Services;
 using MediatR;
@@ -9,7 +10,7 @@ public class CardHandler(
 {
     public async Task<IResult> Handle(GetAllCardQuery query, CancellationToken cancellationToken)
     {
-        var cards = await cardRepository.Get();
+        var cards = await cardRepository.Get() ?? Enumerable.Empty<CardModel>();
         return Results.Ok(cards.OrderBy(c => c.RowColumnId).ThenBy(x => x.IndexPosition));
     }
 }

--- a/Handlers/ColumnRowHandler.cs
+++ b/Handlers/ColumnRowHandler.cs
@@ -14,7 +14,6 @@ public class ColumnRowHandler(
     ISettingsRepository settingsRepository,
     IIconRepository iconRepository,
     IIconConnectedRepository iconConnectedRepository,
-    IWeatherRepository weatherRepository,
     IWeatherDataConnectionRepository weatherDataConnectionRepository,
     IFileService fileService):
     IRequestHandler<GetAllRowColumnsQuery, IResult>,
@@ -164,7 +163,7 @@ public class ColumnRowHandler(
             await iconRepository.Delete(card.IconData.Id);
 
             if (handlerHelper.IconDataHasValue(card.IconData))
-                handlerHelper.DeleteIcon(card);
+                handlerHelper.DeleteIcon(card.IconData);
         }
     }
 

--- a/Handlers/WeatherHandler.cs
+++ b/Handlers/WeatherHandler.cs
@@ -79,10 +79,7 @@ public class WeatherHandler(
      
         var weatherConnnection = (await weatherDataConnectionRepository.GetManyById(command.CardId, null)).FirstOrDefault();
 
-        if (weatherConnnection is null)
-            await weatherDataConnectionRepository.Upsert(WeatherDataConnectionFactory.Create(command.CardId, command.Weather.Id));
-
-        if (weatherConnnection.WeatherId != weather.Id)
+        if (weatherConnnection is null || weatherConnnection.WeatherId != weather.Id)
             await weatherDataConnectionRepository.Upsert(WeatherDataConnectionFactory.Create(command.CardId, weather.Id));
         
         return Results.Ok();

--- a/Helpers/ComponentHandlerHelper.cs
+++ b/Helpers/ComponentHandlerHelper.cs
@@ -11,6 +11,6 @@ public class CardHandlerHelper(IFileService fileService)
         !string.IsNullOrEmpty(iconModel.Type) &&
         !string.IsNullOrEmpty(iconModel.Base64Data);
             
-    public bool DeleteIcon(CardModel Card) =>
-        fileService.DeleteIcon(Card.IconData.Name, Card.IconData.Type);
+    public bool DeleteIcon(IconModel iconData) =>
+        fileService.DeleteIcon(iconData.Name, iconData.Type);
 }

--- a/Models/ColumnRowModel.cs
+++ b/Models/ColumnRowModel.cs
@@ -4,6 +4,6 @@ public class ColumnRowModel
 {
     public int Id { get; set; }
     public int RowPosition { get; set; }
-    public List<CardModel> Cards { get; set; }
+    public required List<CardModel> Cards { get; set; }
     public int RowWidth { get; set; }
 }

--- a/Models/IconModel.cs
+++ b/Models/IconModel.cs
@@ -3,8 +3,8 @@ namespace Gridly.Models;
 public class IconModel
 {
     public int Id {get; set;}
-    public string Name {get; set;}
-    public string Type {get; set;}
-    public string Base64Data {get; set;}
-    public string MaterialIcon {get; set;}
+    public required string Name {get; set;}
+    public required string Type {get; set;}
+    public required string Base64Data {get; set;}
+    public required string MaterialIcon {get; set;}
 }

--- a/Models/ProviderKeyModel.cs
+++ b/Models/ProviderKeyModel.cs
@@ -4,7 +4,7 @@ namespace Gridly.Models;
 public class ProviderKeyModel
 {
     public int Id { get; set; }
-    public string Provider { get; set; }
+    public required string Provider { get; set; }
     public ProvidersKeyStatusEnum KeyStatus { get; set; }
     public DateTime? LastValidatedAt { get; set; }
 }

--- a/Models/VersionModel.cs
+++ b/Models/VersionModel.cs
@@ -5,7 +5,7 @@ namespace Gridly.Models;
 public class VersionModel
 {
     [JsonPropertyName("name")]
-    public string Name { get; set; }
+    public required string Name { get; set; }
     [JsonPropertyName("newRelease")]
     public bool NewRelease { get; set; }
 }

--- a/Models/WeatherDataModel.cs
+++ b/Models/WeatherDataModel.cs
@@ -4,9 +4,9 @@ namespace Gridly.Dtos;
 public class WeatherDataModel
 {
     public int Id { get; set; }
-    public string Address { get; set; }
-    public string Timezone { get; set; }
-    public string Description { get; set; }
+    public required string Address { get; set; }
+    public required string Timezone { get; set; }
+    public required string Description { get; set; }
     public double Temp { get; set; }
     public double FeelsLike { get; set; }
     public double Humidity { get; set; }

--- a/Models/WidgetModel.cs
+++ b/Models/WidgetModel.cs
@@ -3,8 +3,8 @@ namespace Gridly.Models;
 public class WidgetModel
 {
     public int Id {get; set;}
-    public string WidgetType {get; set;}
-    public string Label {get; set;}
-    public string Description {get; set;}
-    public string Icon {get; set;}
+    public required string WidgetType {get; set;}
+    public required string Label {get; set;}
+    public required string Description {get; set;}
+    public required string Icon {get; set;}
 }

--- a/Program.cs
+++ b/Program.cs
@@ -64,10 +64,7 @@ using (var scope = app.Services.CreateScope())
     await dbInit.EnsureTablesCreatedAsync();
 }
 
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllers();
-    endpoints.MapFallbackToFile("index.html");
-});
+app.MapControllers();
+app.MapFallbackToFile("index.html");
 
 app.Run();

--- a/Repositories/ICardRepository.cs
+++ b/Repositories/ICardRepository.cs
@@ -8,6 +8,6 @@ public interface ICardRepository
     public Task<bool> Edit(CardModel Card);
     public Task<bool> BatchEdit(IEnumerable<CardModel>? cards);
     public Task<IEnumerable<CardModel>?> Get();
-    public Task<CardModel> GetById(int Id);
+    public Task<CardModel?> GetById(int Id);
     public Task<bool> Delete(int Id);
 }

--- a/Repositories/IColumnRowRepository.cs
+++ b/Repositories/IColumnRowRepository.cs
@@ -5,7 +5,7 @@ namespace Gridly.Repositories;
 public interface IColumnRowRepository
 {
     public Task<ColumnRowModel> Insert(ColumnRowModel columnRow);
-    public Task<IEnumerable<ColumnRowModel>> Get();
+    public Task<IEnumerable<ColumnRowModel>?> Get();
     public Task<bool> BatchDelete(IEnumerable<ColumnRowModel> columnRows);
     public Task<bool> BatchEdit(IEnumerable<ColumnRowModel> columnRows);
 }

--- a/Repositories/IWeatherRepository.cs
+++ b/Repositories/IWeatherRepository.cs
@@ -4,7 +4,7 @@ namespace Gridly.Repositories;
 
 public interface IWeatherRepository
 {
-    public Task<WeatherDataModel> Get(string address);
-    public Task<IEnumerable<StoredWeatherDataDto>> GetStoredWeatherData();
+    public Task<WeatherDataModel?> Get(string address);
+    public Task<IEnumerable<StoredWeatherDataDto>?> GetStoredWeatherData();
     public Task<WeatherDataModel> Upsert(WeatherDataModel weather);
 }

--- a/Repositories/IconConnectedRepository.cs
+++ b/Repositories/IconConnectedRepository.cs
@@ -33,6 +33,6 @@ public class IconConnectedRepository(IDbConnection connection) : IIconConnectedR
         var builder = new SqlBuilder();
         var template = builder.AddTemplate(QueryStrings.DeleteFromIconsConnectedQuery);
         builder.Where(QueryStrings.WhereCardIdForeignKeyEqualId, new {CardId = cardId});
-        return await _dbCommandRunner.Execute(template.RawSql, template.Parameters) != null;
+        return await _dbCommandRunner.Execute(template.RawSql, template.Parameters);
     }
 }

--- a/Repositories/WeatherDataConnectionRepository.cs
+++ b/Repositories/WeatherDataConnectionRepository.cs
@@ -33,6 +33,6 @@ public class WeatherDataConnectionRepository(IDbConnection connection) : IWeathe
         var builder = new SqlBuilder();
         var template = builder.AddTemplate(QueryStrings.DeleteFromWeatherDataConnectionQuery);
         builder.Where(QueryStrings.WhereCardIdForeignKeyEqualId, new { CardId = cardId });
-        return await _dbCommandRunner.Execute(template.RawSql, template.Parameters) != null;
+        return await _dbCommandRunner.Execute(template.RawSql, template.Parameters);
     }
 }

--- a/Services/MemoryCashingServices.cs
+++ b/Services/MemoryCashingServices.cs
@@ -5,7 +5,7 @@ namespace Gridly.Services;
 public class MemoryCashingServices(IMemoryCache memoryCache) : IMemoryCashingService
     
 {
-    public T Get<T>(string key) where T : class => memoryCache.Get<T>(key);
+    public T? Get<T>(string key) where T : class => memoryCache.Get<T>(key);
     public bool Store<T>(string key, T item) where T : class => 
         memoryCache.Set(
             key, 

--- a/Tests/Factories/CardFactoryTests.cs
+++ b/Tests/Factories/CardFactoryTests.cs
@@ -14,8 +14,13 @@ public class CardFactoryTests
             IndexPosition = 3,
             RowColumnId = 1,
             CardName = "Docs",
+            CardType = "",
             Url = "https://example.test",
-            IconUrl = "/icons/docs.svg"
+            IconUrl = "/icons/docs.svg",
+            IconName = "",
+            Type = "",
+            Base64Data = "",
+            MaterialIcon = ""
         };
 
         var result = CardFactory.Create(dto);
@@ -35,8 +40,8 @@ public class CardFactoryTests
     {
         var dtos = new[]
         {
-            new CardDtoModel { CardId = 1, CardName = "First" },
-            new CardDtoModel { CardId = 2, CardName = "Second" }
+            new CardDtoModel { CardId = 1, CardName = "First", CardType = "", Url = "", IconUrl = "", IconName = "", Type = "", Base64Data = "", MaterialIcon = "" },
+            new CardDtoModel { CardId = 2, CardName = "Second", CardType = "", Url = "", IconUrl = "", IconName = "", Type = "", Base64Data = "", MaterialIcon = "" }
         };
 
         var result = CardFactory.CreateMany(dtos).ToArray();
@@ -54,6 +59,10 @@ public class CardFactoryTests
         var dto = new CardDtoModel
         {
             CardId = 8,
+            CardName = "",
+            CardType = "",
+            Url = "",
+            IconUrl = "",
             IconId = 21,
             IconName = "grid",
             Type = "svg",

--- a/Tests/Handlers/CardHandlerTests.cs
+++ b/Tests/Handlers/CardHandlerTests.cs
@@ -27,8 +27,8 @@ public class CardHandlerTests
             return Task.FromResult(Clone(insertedRow));
         }
 
-        public Task<IEnumerable<ColumnRowModel>> Get() =>
-            Task.FromResult<IEnumerable<ColumnRowModel>>(Rows.Select(Clone).ToList());
+        public Task<IEnumerable<ColumnRowModel>?> Get() =>
+            Task.FromResult<IEnumerable<ColumnRowModel>?>(Rows.Select(Clone).ToList());
 
         public Task<bool> BatchDelete(IEnumerable<ColumnRowModel> columnRows)
         {
@@ -92,8 +92,8 @@ public class CardHandlerTests
         public Task<IEnumerable<CardModel>?> Get() =>
             Task.FromResult<IEnumerable<CardModel>?>(Cards.Select(Clone).ToList());
 
-        public Task<CardModel> GetById(int Id) =>
-            Task.FromResult(Clone(Cards.Single(card => card.Id == Id)));
+        public Task<CardModel?> GetById(int Id) =>
+            Task.FromResult<CardModel?>(Clone(Cards.Single(card => card.Id == Id)));
 
         public Task<bool> Delete(int Id)
         {
@@ -126,7 +126,7 @@ public class CardHandlerTests
     {
         public Task<IconModel> Insert(IconModel icon) => Task.FromResult(icon);
         public Task<IconModel> Edit(IconModel icon) => Task.FromResult(icon);
-        public Task<IconModel> GetById(int Id) => Task.FromResult(new IconModel { Id = Id });
+        public Task<IconModel> GetById(int Id) => Task.FromResult(new IconModel { Id = Id, Name = "", Type = "", Base64Data = "", MaterialIcon = "" });
         public Task<IconModel> GetByFullName(IconModel icon) => Task.FromResult(icon);
         public List<string> FindUnusedIcons(IEnumerable<CardModel> cards) => [];
         public Task<bool> Delete(int Id) => Task.FromResult(true);

--- a/Tests/Handlers/ColumnRowHandlerTests.cs
+++ b/Tests/Handlers/ColumnRowHandlerTests.cs
@@ -36,7 +36,6 @@ public class ColumnRowHandlerTests
             new FakeSettingsRepository(),
             new FakeIconRepository(),
             new FakeIconConnectedRepository(),
-            new FakeWeatherRepository(),
             new FakeWeatherDataConnectionRepository(),
             new FakeFileService());
         var command = new BatchSaveColumnRowCommands
@@ -75,7 +74,6 @@ public class ColumnRowHandlerTests
         {
             Cards = [new CardModel { Id = 10, RowColumnId = 1, IndexPosition = 1, Name = "Plain", Url = "https://plain.example" }],
         };
-        var weatherRepository = new FakeWeatherRepository();
         var weatherDataConnectionRepository = new FakeWeatherDataConnectionRepository();
         var handler = new ColumnRowHandler(
             columnRowRepository,
@@ -83,7 +81,6 @@ public class ColumnRowHandlerTests
             new FakeSettingsRepository(),
             new FakeIconRepository(),
             new FakeIconConnectedRepository(),
-            weatherRepository,
             weatherDataConnectionRepository,
             new FakeFileService());
         var command = new BatchSaveColumnRowCommands
@@ -109,8 +106,8 @@ public class ColumnRowHandlerTests
             return Task.FromResult(Clone(insertedRow));
         }
 
-        public Task<IEnumerable<ColumnRowModel>> Get() =>
-            Task.FromResult<IEnumerable<ColumnRowModel>>(Rows.Select(Clone).ToList());
+        public Task<IEnumerable<ColumnRowModel>?> Get() =>
+            Task.FromResult<IEnumerable<ColumnRowModel>?>(Rows.Select(Clone).ToList());
 
         public Task<bool> BatchDelete(IEnumerable<ColumnRowModel> columnRows)
         {
@@ -166,8 +163,8 @@ public class ColumnRowHandlerTests
         public Task<IEnumerable<CardModel>?> Get() =>
             Task.FromResult<IEnumerable<CardModel>?>(Cards.Select(Clone).ToList());
 
-        public Task<CardModel> GetById(int Id) =>
-            Task.FromResult(Clone(Cards.Single(card => card.Id == Id)));
+        public Task<CardModel?> GetById(int Id) =>
+            Task.FromResult<CardModel?>(Clone(Cards.Single(card => card.Id == Id)));
 
         public Task<bool> Delete(int Id) => Task.FromResult(true);
 
@@ -196,7 +193,7 @@ public class ColumnRowHandlerTests
     {
         public Task<IconModel> Insert(IconModel icon) => Task.FromResult(icon);
         public Task<IconModel> Edit(IconModel icon) => Task.FromResult(icon);
-        public Task<IconModel> GetById(int Id) => Task.FromResult(new IconModel { Id = Id });
+        public Task<IconModel> GetById(int Id) => Task.FromResult(new IconModel { Id = Id, Name = "", Type = "", Base64Data = "", MaterialIcon = "" });
         public Task<IconModel> GetByFullName(IconModel icon) => Task.FromResult(icon);
         public List<string> FindUnusedIcons(IEnumerable<CardModel> cards) => [];
         public Task<bool> Delete(int Id) => Task.FromResult(true);

--- a/Tests/Handlers/WeatherHandlerTests.cs
+++ b/Tests/Handlers/WeatherHandlerTests.cs
@@ -128,8 +128,7 @@ public class WeatherHandlerTests
         var connectionRepository = new FakeWeatherDataConnectionRepository();
         var handler = MakeHandler(weatherRepository: weatherRepository, connectionRepository: connectionRepository);
         
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
-            handler.Handle(new SaveWeatherCommand { Weather = MakeWeather(), CardId = 1 }, CancellationToken.None));
+        await handler.Handle(new SaveWeatherCommand { Weather = MakeWeather(), CardId = 1 }, CancellationToken.None);
 
         Assert.Equal(1, weatherRepository.UpsertCallCount);
         Assert.Equal(1, connectionRepository.UpsertCallCount);
@@ -144,10 +143,8 @@ public class WeatherHandlerTests
         var connectionRepository = new FakeWeatherDataConnectionRepository();
         var handler = MakeHandler(weatherRepository: weatherRepository, connectionRepository: connectionRepository);
 
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
-            handler.Handle(new SaveWeatherCommand { Weather = MakeWeather("Stockholm"), CardId = 1 }, CancellationToken.None));
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
-            handler.Handle(new SaveWeatherCommand { Weather = MakeWeather("Stockholm"), CardId = 2 }, CancellationToken.None));
+        await handler.Handle(new SaveWeatherCommand { Weather = MakeWeather("Stockholm"), CardId = 1 }, CancellationToken.None);
+        await handler.Handle(new SaveWeatherCommand { Weather = MakeWeather("Stockholm"), CardId = 2 }, CancellationToken.None);
 
         var connectionsForCard1 = (await connectionRepository.GetManyById(1, null)).Single();
         var connectionsForCard2 = (await connectionRepository.GetManyById(2, null)).Single();
@@ -161,8 +158,7 @@ public class WeatherHandlerTests
         var connectionRepository = new FakeWeatherDataConnectionRepository();
         var handler = MakeHandler(weatherRepository: weatherRepository, connectionRepository: connectionRepository);
 
-        await Assert.ThrowsAsync<NullReferenceException>(() =>
-            handler.Handle(new SaveWeatherCommand { Weather = MakeWeather("Stockholm"), CardId = 1 }, CancellationToken.None));
+        await handler.Handle(new SaveWeatherCommand { Weather = MakeWeather("Stockholm"), CardId = 1 }, CancellationToken.None);
         var originalWeatherId = (await connectionRepository.GetManyById(1, null)).Single().WeatherId;
 
         await handler.Handle(new SaveWeatherCommand { Weather = MakeWeather("Gothenburg"), CardId = 1 }, CancellationToken.None);

--- a/Tests/Helpers/CardHandlerHelperTests.cs
+++ b/Tests/Helpers/CardHandlerHelperTests.cs
@@ -10,7 +10,7 @@ public class CardHandlerHelperTests
     public void IconDataHasValue_ReturnsTrue_WhenAllFieldsExist()
     {
         var helper = new CardHandlerHelper(new FakeFileService());
-        var icon = new IconModel { Name = "grid", Type = "svg", Base64Data = "Zm9v" };
+        var icon = new IconModel { Name = "grid", Type = "svg", Base64Data = "Zm9v", MaterialIcon = "dashboard" };
 
         var result = helper.IconDataHasValue(icon);
 
@@ -42,7 +42,8 @@ public class CardHandlerHelperTests
         {
             Name = name!,
             Type = type!,
-            Base64Data = base64Data!
+            Base64Data = base64Data!,
+            MaterialIcon = "dashboard"
         };
 
         var result = helper.IconDataHasValue(icon);
@@ -55,9 +56,9 @@ public class CardHandlerHelperTests
     {
         var fileService = new FakeFileService { DeleteIconResult = true };
         var helper = new CardHandlerHelper(fileService);
-        var Card = new CardModel { IconData = new IconModel { Name = "grid", Type = "svg" } };
+        var iconData = new IconModel { Name = "grid", Type = "svg", Base64Data = "", MaterialIcon = "" };
 
-        var result = helper.DeleteIcon(Card);
+        var result = helper.DeleteIcon(iconData);
 
         Assert.True(result);
         Assert.Equal(("grid", "svg"), fileService.DeletedIcon);

--- a/Tests/Infrastructure/TestDoubles.cs
+++ b/Tests/Infrastructure/TestDoubles.cs
@@ -1,13 +1,10 @@
 using Gridly.Commands;
-using Gridly.Commands;
 using Gridly.Dtos;
 using Gridly.EndPoints;
 using Gridly.Models;
 using Gridly.Querys;
-using Gridly.Querys;
 using Gridly.Repositories;
 using Gridly.Services;
-using MediatR;
 using MediatR;
 
 namespace Gridly.Tests.Infrastructure;
@@ -139,10 +136,10 @@ internal sealed class FakeWeatherRepository : IWeatherRepository
         _byAddress[weather.Address] = weather;
     }
 
-    public Task<WeatherDataModel> Get(string address) =>
+    public Task<WeatherDataModel?> Get(string address) =>
         Task.FromResult(_byAddress.TryGetValue(address, out var value) ? value : null);
 
-    public Task<IEnumerable<StoredWeatherDataDto>> GetStoredWeatherData() =>
+    public Task<IEnumerable<StoredWeatherDataDto>?> GetStoredWeatherData() =>
         Task.FromResult<IEnumerable<StoredWeatherDataDto>?>(Array.Empty<StoredWeatherDataDto>());
 
     public Task<WeatherDataModel> Upsert(WeatherDataModel weather)

--- a/Tests/Repositories/IconRepositoryTests.cs
+++ b/Tests/Repositories/IconRepositoryTests.cs
@@ -23,7 +23,7 @@ public sealed class IconRepositoryTests : IDisposable
         {
             new CardModel
             {
-                IconData = new IconModel { Name = "used", Type = "svg" }
+                IconData = new IconModel { Name = "used", Type = "svg", Base64Data = "", MaterialIcon = "" }
             }
         };
 
@@ -47,7 +47,7 @@ public sealed class IconRepositoryTests : IDisposable
         {
             new CardModel
             {
-                IconData = new IconModel { Name = "used", Type = "svg" }
+                IconData = new IconModel { Name = "used", Type = "svg", Base64Data = "", MaterialIcon = "" }
             }
         };
 

--- a/Tests/Repositories/WeatherRepositoryTests.cs
+++ b/Tests/Repositories/WeatherRepositoryTests.cs
@@ -43,6 +43,7 @@ public sealed class WeatherRepositoryTests : IDisposable
 
         Assert.Equal(first.Id, second.Id);
         var stored = await repository.Get("Stockholm");
+        Assert.NotNull(stored);
         Assert.Equal("cloudy", stored.Description);
         var rowCount = await _connection.QuerySingleAsync<int>("SELECT COUNT(*) FROM WeatherData;");
         Assert.Equal(1, rowCount);

--- a/Tests/Services/FileServiceTests.cs
+++ b/Tests/Services/FileServiceTests.cs
@@ -53,7 +53,8 @@ public sealed class FileServiceTests : IDisposable
         {
             Name = fileName,
             Type = "png",
-            Base64Data = Convert.ToBase64String([5, 6, 7])
+            Base64Data = Convert.ToBase64String([5, 6, 7]),
+            MaterialIcon = ""
         };
 
         var result = _service.UploadIcon(icon);


### PR DESCRIPTION
Fix every warning surfaced by dotnet build/test (nullability mismatches, missing required members, dead parameters, legacy routing, NuGet advisories) and add TreatWarningsAsErrors so the codebase stays at 0 warnings going forward. Along the way, fixed a real NullReferenceException bug in WeatherHandler.Handle(SaveWeatherCommand) where a null weather connection was dereferenced instead of triggering the upsert branch.