### PR TITLE
Add backend test coverage and CI coverage gate (#316)

### DIFF
--- a/.github/workflows/Build_Test_Branches.yml
+++ b/.github/workflows/Build_Test_Branches.yml
@@ -54,5 +54,17 @@ jobs:
         working-directory: ${{ env.DOTNET_PATH }}
 
       - name: Test .NET
-        run: dotnet test Gridly.csproj --configuration Release --no-build
+        run: >
+          dotnet test Gridly.csproj --configuration Release --no-build
+          --collect:"XPlat Code Coverage" --settings coverage.runsettings
+          --results-directory ./TestResults
+        working-directory: ${{ env.DOTNET_PATH }}
+
+      - name: Enforce .NET coverage threshold
+        run: |
+          COVERAGE_FILE=$(find TestResults -name "coverage.cobertura.xml" | head -n 1)
+          LINE_RATE=$(grep -oP 'line-rate="\K[0-9.]+' "$COVERAGE_FILE" | head -n 1)
+          COVERAGE_PERCENT=$(awk "BEGIN { printf \"%.2f\", $LINE_RATE * 100 }")
+          echo "Backend line coverage: ${COVERAGE_PERCENT}% (threshold: 80%)"
+          awk -v rate="$LINE_RATE" 'BEGIN { exit (rate < 0.80) }'
         working-directory: ${{ env.DOTNET_PATH }}

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ testem.log
 # Files I wanna ignore
 Assets/CardData/*.json
 Assets/VersionData/*.json
+
+# .NET test results / coverage output
+/TestResults
 Assets/Icons/*
 Assets/Db/*
 /wwwroot/

--- a/Factories/WeatherDataFactory.cs
+++ b/Factories/WeatherDataFactory.cs
@@ -6,17 +6,18 @@ public class WeatherDataFactory
 {
     public static WeatherDataModel Create(WeatherDataDto dto)
     {
-        var day = dto.days.FirstOrDefault();
+        var day = dto.days.FirstOrDefault()
+            ?? throw new InvalidOperationException("Weather data contains no days.");
         return new()
         {
             Address = dto.address,
             Timezone = dto.timezone,
             Description = dto.description,
-            Temp = day!.temp,
-            FeelsLike = day!.feelslike,
-            Humidity = day!.humidity,
-            WindSpeed = day!.windspeed,
-            WindDir = day!.windDir,
+            Temp = day.temp,
+            FeelsLike = day.feelslike,
+            Humidity = day.humidity,
+            WindSpeed = day.windspeed,
+            WindDir = day.windDir,
             FetchedAt = dto.fetchedAt,
         };
     }

--- a/Tests/EndPoints/ProvidersEndPointTests.cs
+++ b/Tests/EndPoints/ProvidersEndPointTests.cs
@@ -1,0 +1,39 @@
+using Gridly.Constants;
+using Gridly.EndPoints;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.EndPoints;
+
+public class ProvidersEndPointTests
+{
+    [Fact]
+    public async Task Validate_CallsWeatherProviderWithProbeLocationAndKey_ReturnsStatusCode()
+    {
+        var providersEndPointExtensions = new FakeProvidersEndPointExtensions
+        {
+            Result = (StatusCodes.Status200OK, "{}")
+        };
+        var endPoint = new ProvidersEndPoint(providersEndPointExtensions);
+
+        var status = await endPoint.Validate("raw-key");
+
+        Assert.Equal(StatusCodes.Status200OK, status);
+        Assert.Equal(EndpointStrings.VisualCrossingProbeLocation, providersEndPointExtensions.LastAddress);
+        Assert.Equal(EndpointStrings.GetVisualCrossingWeatherData, providersEndPointExtensions.LastProvider);
+        Assert.Equal("raw-key", providersEndPointExtensions.LastRawKey);
+    }
+
+    [Fact]
+    public async Task Validate_WhenProviderRejectsKey_ReturnsProviderStatusCodeUnchanged()
+    {
+        var providersEndPointExtensions = new FakeProvidersEndPointExtensions
+        {
+            Result = (StatusCodes.Status401Unauthorized, "denied")
+        };
+        var endPoint = new ProvidersEndPoint(providersEndPointExtensions);
+
+        var status = await endPoint.Validate("bad-key");
+
+        Assert.Equal(StatusCodes.Status401Unauthorized, status);
+    }
+}

--- a/Tests/EndPoints/VersionEndPointTests.cs
+++ b/Tests/EndPoints/VersionEndPointTests.cs
@@ -1,0 +1,56 @@
+using Gridly.Constants;
+using Gridly.EndPoints;
+using Gridly.Models;
+using Gridly.Services;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.EndPoints;
+
+public class VersionEndPointTests
+{
+    [Fact]
+    public async Task GetVersion_WhenSuccessful_ReturnsDeserializedVersion()
+    {
+        var httpClient = new FakeHttpClientServices
+        {
+            Response = (true, """{"name":"1.2.3","newRelease":false}""")
+        };
+        var endPoint = new VersionEndPoint(new DataConverter<VersionModel>(), httpClient);
+
+        var (success, version) = await endPoint.GetVersion();
+
+        Assert.True(success);
+        Assert.NotNull(version);
+        Assert.Equal("1.2.3", version.Name);
+        Assert.Equal(EndpointStrings.GetVersionInternalEndPoint, httpClient.LastUrl);
+    }
+
+    [Fact]
+    public async Task GetVersion_WhenUnsuccessful_ReturnsNullVersion()
+    {
+        var httpClient = new FakeHttpClientServices { Response = (false, string.Empty) };
+        var endPoint = new VersionEndPoint(new DataConverter<VersionModel>(), httpClient);
+
+        var (success, version) = await endPoint.GetVersion();
+
+        Assert.False(success);
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public async Task GetLatestVersion_WhenSuccessful_CallsRemoteEndpointAndReturnsVersion()
+    {
+        var httpClient = new FakeHttpClientServices
+        {
+            Response = (true, """{"name":"2.0.0","newRelease":true}""")
+        };
+        var endPoint = new VersionEndPoint(new DataConverter<VersionModel>(), httpClient);
+
+        var (success, version) = await endPoint.GetLatestVersion();
+
+        Assert.True(success);
+        Assert.NotNull(version);
+        Assert.True(version.NewRelease);
+        Assert.Equal(EndpointStrings.GetVersionRemoteEndPoint, httpClient.LastUrl);
+    }
+}

--- a/Tests/EndPoints/WeatherEndPointTests.cs
+++ b/Tests/EndPoints/WeatherEndPointTests.cs
@@ -1,0 +1,42 @@
+using Gridly.Constants;
+using Gridly.Dtos;
+using Gridly.EndPoints;
+using Gridly.Services;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.EndPoints;
+
+public class WeatherEndPointTests
+{
+    [Fact]
+    public async Task Get_WhenStatusIsOk_DeserializesWeatherData()
+    {
+        const string json = """{"address":"London","timezone":"Europe/London","description":"Sunny","days":[{"temp":20,"feelslike":19,"humidity":50,"windspeed":4,"windDir":90}],"fetchedAt":"2026-08-17T00:00:00"}""";
+        var providersEndPointExtensions = new FakeProvidersEndPointExtensions
+        {
+            Result = (StatusCodes.Status200OK, json)
+        };
+        var endPoint = new WeatherEndPoint(new DataConverter<WeatherDataDto>(), providersEndPointExtensions);
+
+        var (status, weather) = await endPoint.Get("London", "raw-key");
+
+        Assert.Equal(StatusCodes.Status200OK, status);
+        Assert.NotNull(weather);
+        Assert.Equal("London", weather.address);
+        Assert.Equal("raw-key", providersEndPointExtensions.LastRawKey);
+        Assert.Equal(EndpointStrings.GetVisualCrossingWeatherData, providersEndPointExtensions.LastProvider);
+    }
+
+    [Fact]
+    public async Task Get_WhenStatusIsNotOk_ThrowsHttpRequestException()
+    {
+        var providersEndPointExtensions = new FakeProvidersEndPointExtensions
+        {
+            Result = (StatusCodes.Status401Unauthorized, "denied")
+        };
+        var endPoint = new WeatherEndPoint(new DataConverter<WeatherDataDto>(), providersEndPointExtensions);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => endPoint.Get("London", "raw-key"));
+        Assert.Contains("401", exception.Message);
+    }
+}

--- a/Tests/Factories/ColumnRowFactoryTests.cs
+++ b/Tests/Factories/ColumnRowFactoryTests.cs
@@ -1,0 +1,58 @@
+using Gridly.Dtos;
+using Gridly.Factories;
+using Gridly.Models;
+
+namespace Gridly.Tests.Factories;
+
+public class ColumnRowFactoryTests
+{
+    [Fact]
+    public void Create_MapsDtoFieldsToColumnRowModel()
+    {
+        var dto = new ColumnRowDtoModel
+        {
+            Id = 4,
+            RowPosition = 2,
+            RowWidth = 12,
+            Cards = Array.Empty<CardModel>()
+        };
+
+        var result = ColumnRowFactory.Create(dto);
+
+        Assert.Equal(dto.Id, result.Id);
+        Assert.Equal(dto.RowPosition, result.RowPosition);
+        Assert.Equal(dto.RowWidth, result.RowWidth);
+    }
+
+    [Fact]
+    public void Create_AlwaysInitializesEmptyCardsList()
+    {
+        var dto = new ColumnRowDtoModel
+        {
+            Id = 1,
+            RowPosition = 0,
+            RowWidth = 12,
+            Cards = new[] { new CardModel { Id = 1, Name = "", Url = "", IconUrl = "" } }
+        };
+
+        var result = ColumnRowFactory.Create(dto);
+
+        Assert.Empty(result.Cards);
+    }
+
+    [Fact]
+    public void CreateMany_PreservesOrderAndCount()
+    {
+        var dtos = new[]
+        {
+            new ColumnRowDtoModel { Id = 1, RowPosition = 0, RowWidth = 12, Cards = Array.Empty<CardModel>() },
+            new ColumnRowDtoModel { Id = 2, RowPosition = 1, RowWidth = 6, Cards = Array.Empty<CardModel>() }
+        };
+
+        var result = ColumnRowFactory.CreateMany(dtos).ToArray();
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal(1, result[0].Id);
+        Assert.Equal(2, result[1].Id);
+    }
+}

--- a/Tests/Factories/IconConnectedFactoryTests.cs
+++ b/Tests/Factories/IconConnectedFactoryTests.cs
@@ -1,0 +1,15 @@
+using Gridly.Factories;
+
+namespace Gridly.Tests.Factories;
+
+public class IconConnectedFactoryTests
+{
+    [Fact]
+    public void Create_MapsCardAndIconIds()
+    {
+        var result = IconConnectedFactory.Create(4, 9);
+
+        Assert.Equal(4, result.CardId);
+        Assert.Equal(9, result.IconId);
+    }
+}

--- a/Tests/Factories/SettingsFactoryTests.cs
+++ b/Tests/Factories/SettingsFactoryTests.cs
@@ -1,0 +1,37 @@
+using Gridly.Factories;
+using Gridly.Models;
+
+namespace Gridly.Tests.Factories;
+
+public class SettingsFactoryTests
+{
+    [Fact]
+    public void Create_WithNullInput_ReturnsDefaults()
+    {
+        var result = SettingsFactory.Create(null);
+
+        Assert.Equal(250, result.Width);
+        Assert.Equal(250, result.Height);
+        Assert.False(result.TitleHidden);
+        Assert.False(result.ImageHidden);
+    }
+
+    [Fact]
+    public void Create_WithValues_PreservesProvidedValues()
+    {
+        var settings = new SettingsModel
+        {
+            Width = 500,
+            Height = 300,
+            TitleHidden = true,
+            ImageHidden = true
+        };
+
+        var result = SettingsFactory.Create(settings);
+
+        Assert.Equal(500, result.Width);
+        Assert.Equal(300, result.Height);
+        Assert.True(result.TitleHidden);
+        Assert.True(result.ImageHidden);
+    }
+}

--- a/Tests/Factories/WeatherDataConnectionFactoryTests.cs
+++ b/Tests/Factories/WeatherDataConnectionFactoryTests.cs
@@ -1,0 +1,15 @@
+using Gridly.Factories;
+
+namespace Gridly.Tests.Factories;
+
+public class WeatherDataConnectionFactoryTests
+{
+    [Fact]
+    public void Create_MapsCardAndWeatherIds()
+    {
+        var result = WeatherDataConnectionFactory.Create(7, 15);
+
+        Assert.Equal(7, result.CardId);
+        Assert.Equal(15, result.WeatherId);
+    }
+}

--- a/Tests/Factories/WeatherDataFactoryTests.cs
+++ b/Tests/Factories/WeatherDataFactoryTests.cs
@@ -1,0 +1,47 @@
+using Gridly.Dtos;
+using Gridly.Factories;
+
+namespace Gridly.Tests.Factories;
+
+public class WeatherDataFactoryTests
+{
+    [Fact]
+    public void Create_MapsDtoFieldsFromFirstDay()
+    {
+        var dto = new WeatherDataDto(
+            address: "Stockholm",
+            timezone: "Europe/Stockholm",
+            description: "Cloudy",
+            days: new[]
+            {
+                new DaysDto(temp: 12.5, feelslike: 11.0, humidity: 80, windspeed: 5.5, windDir: 180),
+                new DaysDto(temp: 20.0, feelslike: 19.0, humidity: 60, windspeed: 3.0, windDir: 90)
+            },
+            fetchedAt: new DateTime(2026, 8, 17));
+
+        var result = WeatherDataFactory.Create(dto);
+
+        Assert.Equal("Stockholm", result.Address);
+        Assert.Equal("Europe/Stockholm", result.Timezone);
+        Assert.Equal("Cloudy", result.Description);
+        Assert.Equal(12.5, result.Temp);
+        Assert.Equal(11.0, result.FeelsLike);
+        Assert.Equal(80, result.Humidity);
+        Assert.Equal(5.5, result.WindSpeed);
+        Assert.Equal(180, result.WindDir);
+        Assert.Equal(dto.fetchedAt, result.FetchedAt);
+    }
+
+    [Fact]
+    public void Create_WithNoDays_ThrowsInvalidOperationException()
+    {
+        var dto = new WeatherDataDto(
+            address: "Stockholm",
+            timezone: "Europe/Stockholm",
+            description: "Cloudy",
+            days: Array.Empty<DaysDto>(),
+            fetchedAt: DateTime.UtcNow);
+
+        Assert.Throws<InvalidOperationException>(() => WeatherDataFactory.Create(dto));
+    }
+}

--- a/Tests/Factories/WidgetFactoryTests.cs
+++ b/Tests/Factories/WidgetFactoryTests.cs
@@ -1,0 +1,44 @@
+using Gridly.Dtos;
+using Gridly.Factories;
+
+namespace Gridly.Tests.Factories;
+
+public class WidgetFactoryTests
+{
+    [Fact]
+    public void Create_MapsDtoFieldsToWidgetModel()
+    {
+        var dto = new WidgetDtoModel
+        {
+            Id = 3,
+            WidgetType = "Weather",
+            Label = "Weather widget",
+            Description = "Shows the local forecast",
+            Icon = "cloud"
+        };
+
+        var result = WidgetFactory.Create(dto);
+
+        Assert.Equal(dto.Id, result.Id);
+        Assert.Equal(dto.WidgetType, result.WidgetType);
+        Assert.Equal(dto.Label, result.Label);
+        Assert.Equal(dto.Description, result.Description);
+        Assert.Equal(dto.Icon, result.Icon);
+    }
+
+    [Fact]
+    public void CreateMany_PreservesOrderAndCount()
+    {
+        var dtos = new[]
+        {
+            new WidgetDtoModel { Id = 1, WidgetType = "Empty", Label = "Empty", Description = "", Icon = "" },
+            new WidgetDtoModel { Id = 2, WidgetType = "Custom", Label = "Custom", Description = "", Icon = "" }
+        };
+
+        var result = WidgetFactory.CreateMany(dtos).ToArray();
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal("Empty", result[0].WidgetType);
+        Assert.Equal("Custom", result[1].WidgetType);
+    }
+}

--- a/Tests/Handlers/LocalProvidersHandlerTests.cs
+++ b/Tests/Handlers/LocalProvidersHandlerTests.cs
@@ -1,0 +1,81 @@
+using Gridly.Dtos;
+using Gridly.Enums;
+using Gridly.Handlers;
+using Gridly.Models;
+using Gridly.Querys;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.Handlers;
+
+public class LocalProvidersHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenProviderIsBlank_ReturnsBadRequest()
+    {
+        var repository = new FakeLocalProvidersRepository();
+        var handler = new LocalProvidersHandler(repository);
+
+        var result = await handler.Handle(new GetLocalProviderKeyStatusQuery { Provider = "  " }, CancellationToken.None);
+
+        ResultAssertions.AssertStatusCode(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoKeyIsStored_ReturnsOkWithUnknownStatus()
+    {
+        var repository = new FakeLocalProvidersRepository();
+        var handler = new LocalProvidersHandler(repository);
+
+        var result = await handler.Handle(new GetLocalProviderKeyStatusQuery { Provider = "VisualCrossing" }, CancellationToken.None);
+
+        var status = ResultAssertions.AssertOk<ProviderKeyStatusModel>(result);
+        Assert.False(status.Exists);
+        Assert.Equal(ProvidersKeyStatusEnum.Unknown, status.KeyStatus);
+        Assert.Equal(0, repository.UpdateStatusCallCount);
+    }
+
+    [Fact]
+    public async Task Handle_WhenStoredKeyIsValid_ReturnsOkWithValidStatusAndUpdatesStatus()
+    {
+        var repository = new FakeLocalProvidersRepository
+        {
+            StoredKey = new ProviderKeyDtoModel
+            {
+                Provider = "VisualCrossing",
+                EncryptedKey = "encrypted",
+                Status = nameof(ProvidersKeyStatusEnum.Valid),
+            },
+        };
+        var handler = new LocalProvidersHandler(repository);
+
+        var result = await handler.Handle(new GetLocalProviderKeyStatusQuery { Provider = "VisualCrossing" }, CancellationToken.None);
+
+        var status = ResultAssertions.AssertOk<ProviderKeyStatusModel>(result);
+        Assert.True(status.Exists);
+        Assert.Equal(ProvidersKeyStatusEnum.Valid, status.KeyStatus);
+        Assert.Equal(1, repository.UpdateStatusCallCount);
+        Assert.Equal(nameof(ProvidersKeyStatusEnum.Valid), repository.LastUpdatedStatus);
+    }
+
+    [Fact]
+    public async Task Handle_WhenStoredKeyIsNotValid_ReturnsOkWithInvalidStatus()
+    {
+        var repository = new FakeLocalProvidersRepository
+        {
+            StoredKey = new ProviderKeyDtoModel
+            {
+                Provider = "VisualCrossing",
+                EncryptedKey = "encrypted",
+                Status = nameof(ProvidersKeyStatusEnum.Unknown),
+            },
+        };
+        var handler = new LocalProvidersHandler(repository);
+
+        var result = await handler.Handle(new GetLocalProviderKeyStatusQuery { Provider = "VisualCrossing" }, CancellationToken.None);
+
+        var status = ResultAssertions.AssertOk<ProviderKeyStatusModel>(result);
+        Assert.True(status.Exists);
+        Assert.Equal(ProvidersKeyStatusEnum.Invalid, status.KeyStatus);
+        Assert.Equal(nameof(ProvidersKeyStatusEnum.Invalid), repository.LastUpdatedStatus);
+    }
+}

--- a/Tests/Handlers/WidgetHandlerTests.cs
+++ b/Tests/Handlers/WidgetHandlerTests.cs
@@ -1,0 +1,39 @@
+using Gridly.Handlers;
+using Gridly.Models;
+using Gridly.Querys;
+using Gridly.Tests.Infrastructure;
+
+namespace Gridly.Tests.Handlers;
+
+public class WidgetHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenWidgetsExist_ReturnsOkWithList()
+    {
+        var repository = new FakeWidgetRepository
+        {
+            Widgets =
+            [
+                new WidgetModel { Id = 1, WidgetType = "Empty", Label = "Empty", Description = "", Icon = "" },
+                new WidgetModel { Id = 2, WidgetType = "Custom", Label = "Custom", Description = "", Icon = "" },
+            ],
+        };
+        var handler = new WidgetHandler(repository);
+
+        var result = await handler.Handle(new GetWidgetQuery(), CancellationToken.None);
+
+        var widgets = ResultAssertions.AssertOk<List<WidgetModel>>(result);
+        Assert.Equal(2, widgets.Count);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoWidgetsExist_ReturnsNoContent()
+    {
+        var repository = new FakeWidgetRepository();
+        var handler = new WidgetHandler(repository);
+
+        var result = await handler.Handle(new GetWidgetQuery(), CancellationToken.None);
+
+        ResultAssertions.AssertStatusCode(result, StatusCodes.Status204NoContent);
+    }
+}

--- a/Tests/Infrastructure/FakeHostEnvironment.cs
+++ b/Tests/Infrastructure/FakeHostEnvironment.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace Gridly.Tests.Infrastructure;
+
+internal sealed class FakeHostEnvironment : IHostEnvironment
+{
+    public string ApplicationName { get; set; } = "Gridly.Tests";
+    public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    public string ContentRootPath { get; set; } = string.Empty;
+    public string EnvironmentName { get; set; } = "Development";
+}

--- a/Tests/Infrastructure/TestDoubles.cs
+++ b/Tests/Infrastructure/TestDoubles.cs
@@ -1,6 +1,7 @@
 using Gridly.Commands;
 using Gridly.Dtos;
 using Gridly.EndPoints;
+using Gridly.helpers;
 using Gridly.Models;
 using Gridly.Querys;
 using Gridly.Repositories;
@@ -128,6 +129,7 @@ internal sealed class FakeWeatherRepository : IWeatherRepository
 
     public int UpsertCallCount { get; private set; }
     public bool DeleteIfOrphanedResult { get; set; } = true;
+    public IEnumerable<StoredWeatherDataDto>? StoredWeatherData { get; set; } = Array.Empty<StoredWeatherDataDto>();
 
     public void Seed(WeatherDataModel weather)
     {
@@ -140,7 +142,7 @@ internal sealed class FakeWeatherRepository : IWeatherRepository
         Task.FromResult(_byAddress.TryGetValue(address, out var value) ? value : null);
 
     public Task<IEnumerable<StoredWeatherDataDto>?> GetStoredWeatherData() =>
-        Task.FromResult<IEnumerable<StoredWeatherDataDto>?>(Array.Empty<StoredWeatherDataDto>());
+        Task.FromResult(StoredWeatherData);
 
     public Task<WeatherDataModel> Upsert(WeatherDataModel weather)
     {
@@ -297,6 +299,32 @@ internal sealed class FakeProvidersEndPoint : IProvidersEndPoint
     public Task<int> Validate(string provider)
     {
         ValidateCallCount++;
+        return Task.FromResult(Result);
+    }
+}
+
+internal sealed class FakeWidgetRepository : IWidgetRepository
+{
+    public List<WidgetModel> Widgets { get; set; } = [];
+
+    public Task<IEnumerable<WidgetModel>> Get() =>
+        Task.FromResult<IEnumerable<WidgetModel>>(Widgets);
+}
+
+internal sealed class FakeProvidersEndPointExtensions : IProvidersEndPointExtensions
+{
+    public int CallCount { get; private set; }
+    public string? LastAddress { get; private set; }
+    public string? LastProvider { get; private set; }
+    public string? LastRawKey { get; private set; }
+    public (int Status, string Body) Result { get; set; } = (StatusCodes.Status200OK, "{}");
+
+    public Task<(int Status, string Body)> CallWeatherProvider(string address, string provider, string rawKey)
+    {
+        CallCount++;
+        LastAddress = address;
+        LastProvider = provider;
+        LastRawKey = rawKey;
         return Task.FromResult(Result);
     }
 }

--- a/Tests/Repositories/CardRepositoryTests.cs
+++ b/Tests/Repositories/CardRepositoryTests.cs
@@ -1,0 +1,165 @@
+using System.Data;
+using Dapper;
+using Gridly.Data;
+using Gridly.Models;
+using Gridly.Repositories;
+using Microsoft.Data.Sqlite;
+
+namespace Gridly.Tests.Repositories;
+
+public sealed class CardRepositoryTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"gridly-cards-{Guid.NewGuid():N}.db");
+    private readonly IDbConnection _connection;
+
+    public CardRepositoryTests()
+    {
+        _connection = new SqliteConnection($"Data Source={_dbPath}");
+    }
+
+    private async Task<int> SeedRowColumnAsync()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var rowColumnId = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO RowColumn (RowPosition, RowWidth) VALUES (1,1); SELECT last_insert_rowid();");
+        return (int)rowColumnId;
+    }
+
+    [Fact]
+    public async Task Insert_CreatesCardAndReturnsGeneratedId()
+    {
+        var rowColumnId = await SeedRowColumnAsync();
+        var repository = new CardRepository(_connection);
+
+        var result = await repository.Insert(new CardModel
+        {
+            IndexPosition = 1,
+            RowColumnId = rowColumnId,
+            Name = "Docs",
+            Url = "https://example.test",
+            IconUrl = "/icons/docs.svg",
+            Type = "",
+        });
+
+        Assert.True(result.Id > 0);
+        Assert.Equal("Docs", result.Name);
+    }
+
+    [Fact]
+    public async Task Edit_UpdatesNameAndUrl()
+    {
+        var rowColumnId = await SeedRowColumnAsync();
+        var repository = new CardRepository(_connection);
+        var card = await repository.Insert(new CardModel
+        {
+            IndexPosition = 1,
+            RowColumnId = rowColumnId,
+            Name = "Original",
+            Url = "https://original.test",
+            IconUrl = "",
+            Type = "",
+        });
+
+        card.Name = "Renamed";
+        card.Url = "https://renamed.test";
+        var edited = await repository.Edit(card);
+
+        Assert.True(edited);
+        var stored = await repository.GetById(card.Id);
+        Assert.NotNull(stored);
+        Assert.Equal("Renamed", stored.Name);
+        Assert.Equal("https://renamed.test", stored.Url);
+    }
+
+    [Fact]
+    public async Task BatchEdit_UpdatesIndexPositionAndSettings()
+    {
+        var rowColumnId = await SeedRowColumnAsync();
+        var repository = new CardRepository(_connection);
+        var card = await repository.Insert(new CardModel
+        {
+            IndexPosition = 1,
+            RowColumnId = rowColumnId,
+            Name = "Card",
+            Url = "",
+            IconUrl = "",
+            Type = "",
+        });
+        await _connection.ExecuteAsync(
+            "INSERT INTO Settings (CardId, Width, Height, TitleHidden, ImageHidden) VALUES (@CardId, 250, 250, 0, 0);",
+            new { CardId = card.Id });
+
+        var result = await repository.BatchEdit(new[]
+        {
+            new CardModel
+            {
+                Id = card.Id,
+                IndexPosition = 5,
+                RowColumnId = rowColumnId,
+                Settings = new SettingsModel { Width = 400, Height = 300 },
+            },
+        });
+
+        Assert.True(result);
+        var stored = await repository.GetById(card.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(5, stored.IndexPosition);
+        Assert.NotNull(stored.Settings);
+        Assert.Equal(400, stored.Settings.Width);
+        Assert.Equal(300, stored.Settings.Height);
+    }
+
+    [Fact]
+    public async Task BatchEdit_WhenCardsIsNull_ReturnsFalse()
+    {
+        await SeedRowColumnAsync();
+        var repository = new CardRepository(_connection);
+
+        var result = await repository.BatchEdit(null);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsCardsOrderedByIndexPositionWithJoinedIconAndSettings()
+    {
+        var rowColumnId = await SeedRowColumnAsync();
+        var iconId = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO Icon (Name, Type, Base64Data, MaterialIcon) VALUES ('grid','svg','Zm9v','dashboard'); SELECT last_insert_rowid();");
+        var repository = new CardRepository(_connection);
+        var second = await repository.Insert(new CardModel { IndexPosition = 2, RowColumnId = rowColumnId, Name = "Second", Url = "", IconUrl = "", Type = "" });
+        var first = await repository.Insert(new CardModel { IndexPosition = 1, RowColumnId = rowColumnId, Name = "First", Url = "", IconUrl = "", Type = "" });
+        await _connection.ExecuteAsync(
+            "INSERT INTO IconsConnected (CardId, IconId) VALUES (@CardId, @IconId);",
+            new { CardId = first.Id, IconId = iconId });
+
+        var result = (await repository.Get())!.ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("First", result[0].Name);
+        Assert.Equal("Second", result[1].Name);
+        Assert.Equal("grid", result[0].IconData!.Name);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesCard()
+    {
+        var rowColumnId = await SeedRowColumnAsync();
+        var repository = new CardRepository(_connection);
+        var card = await repository.Insert(new CardModel { IndexPosition = 1, RowColumnId = rowColumnId, Name = "ToDelete", Url = "", IconUrl = "", Type = "" });
+
+        var result = await repository.Delete(card.Id);
+
+        Assert.True(result);
+        var remaining = await repository.Get();
+        Assert.Empty(remaining!);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        if (File.Exists(_dbPath + ".bak")) File.Delete(_dbPath + ".bak");
+    }
+}

--- a/Tests/Repositories/ColumnRowRepositoryTests.cs
+++ b/Tests/Repositories/ColumnRowRepositoryTests.cs
@@ -1,0 +1,89 @@
+using System.Data;
+using Dapper;
+using Gridly.Data;
+using Gridly.Models;
+using Gridly.Repositories;
+using Microsoft.Data.Sqlite;
+
+namespace Gridly.Tests.Repositories;
+
+public sealed class ColumnRowRepositoryTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"gridly-columnrows-{Guid.NewGuid():N}.db");
+    private readonly IDbConnection _connection;
+
+    public ColumnRowRepositoryTests()
+    {
+        _connection = new SqliteConnection($"Data Source={_dbPath}");
+    }
+
+    [Fact]
+    public async Task Insert_CreatesRowAndReturnsGeneratedId()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new ColumnRowRepository(_connection);
+
+        var result = await repository.Insert(new ColumnRowModel { RowPosition = 1, RowWidth = 12, Cards = [] });
+
+        Assert.True(result.Id > 0);
+        Assert.Equal(1, result.RowPosition);
+        Assert.Equal(12, result.RowWidth);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsRowsOrderedByRowPosition()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new ColumnRowRepository(_connection);
+        await repository.Insert(new ColumnRowModel { RowPosition = 2, RowWidth = 12, Cards = [] });
+        await repository.Insert(new ColumnRowModel { RowPosition = 1, RowWidth = 6, Cards = [] });
+
+        var result = (await repository.Get())!.ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].RowPosition);
+        Assert.Equal(2, result[1].RowPosition);
+    }
+
+    [Fact]
+    public async Task BatchDelete_RemovesGivenRows()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new ColumnRowRepository(_connection);
+        var row1 = await repository.Insert(new ColumnRowModel { RowPosition = 1, RowWidth = 12, Cards = [] });
+        var row2 = await repository.Insert(new ColumnRowModel { RowPosition = 2, RowWidth = 12, Cards = [] });
+
+        var result = await repository.BatchDelete(new[] { row1 });
+
+        Assert.True(result);
+        var remaining = (await repository.Get())!.ToList();
+        Assert.Single(remaining);
+        Assert.Equal(row2.Id, remaining[0].Id);
+    }
+
+    [Fact]
+    public async Task BatchEdit_UpdatesRowPositionAndWidth()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new ColumnRowRepository(_connection);
+        var row = await repository.Insert(new ColumnRowModel { RowPosition = 1, RowWidth = 12, Cards = [] });
+
+        var result = await repository.BatchEdit(new[]
+        {
+            new ColumnRowModel { Id = row.Id, RowPosition = 3, RowWidth = 8, Cards = [] },
+        });
+
+        Assert.True(result);
+        var stored = (await repository.Get())!.Single();
+        Assert.Equal(3, stored.RowPosition);
+        Assert.Equal(8, stored.RowWidth);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        if (File.Exists(_dbPath + ".bak")) File.Delete(_dbPath + ".bak");
+    }
+}

--- a/Tests/Repositories/IconConnectedRepositoryTests.cs
+++ b/Tests/Repositories/IconConnectedRepositoryTests.cs
@@ -1,0 +1,114 @@
+using System.Data;
+using Dapper;
+using Gridly.Data;
+using Gridly.Dtos;
+using Gridly.Repositories;
+using Microsoft.Data.Sqlite;
+
+namespace Gridly.Tests.Repositories;
+
+public sealed class IconConnectedRepositoryTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"gridly-iconsconnected-{Guid.NewGuid():N}.db");
+    private readonly IDbConnection _connection;
+
+    public IconConnectedRepositoryTests()
+    {
+        _connection = new SqliteConnection($"Data Source={_dbPath}");
+    }
+
+    private async Task<(int card1, int card2, int icon1, int icon2)> SeedFixtureAsync()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var rowColumnId = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO RowColumn (RowPosition, RowWidth) VALUES (1,1); SELECT last_insert_rowid();");
+        var card1 = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO Card (IndexPosition, RowColumnId, Name, Url, Type, IconUrl) VALUES (1, @row, 'A', '', '', ''); SELECT last_insert_rowid();",
+            new { row = rowColumnId });
+        var card2 = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO Card (IndexPosition, RowColumnId, Name, Url, Type, IconUrl) VALUES (2, @row, 'B', '', '', ''); SELECT last_insert_rowid();",
+            new { row = rowColumnId });
+        var icon1 = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO Icon (Name, Type, Base64Data, MaterialIcon) VALUES ('grid','svg','',''); SELECT last_insert_rowid();");
+        var icon2 = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO Icon (Name, Type, Base64Data, MaterialIcon) VALUES ('box','svg','',''); SELECT last_insert_rowid();");
+        return ((int)card1, (int)card2, (int)icon1, (int)icon2);
+    }
+
+    [Fact]
+    public async Task Insert_CreatesConnectionAndReturnsGeneratedId()
+    {
+        var (card1, _, icon1, _) = await SeedFixtureAsync();
+        var repository = new IconConnectedRepository(_connection);
+
+        var result = await repository.Insert(new IconConnectedDtoModel { CardId = card1, IconId = icon1 });
+
+        Assert.True(result.Id > 0);
+        Assert.Equal(card1, result.CardId);
+        Assert.Equal(icon1, result.IconId);
+    }
+
+    [Fact]
+    public async Task GetManyById_FiltersByCardId()
+    {
+        var (card1, card2, icon1, _) = await SeedFixtureAsync();
+        var repository = new IconConnectedRepository(_connection);
+        await repository.Insert(new IconConnectedDtoModel { CardId = card1, IconId = icon1 });
+        await repository.Insert(new IconConnectedDtoModel { CardId = card2, IconId = icon1 });
+
+        var result = await repository.GetManyById(card1, null);
+
+        var connection = Assert.Single(result);
+        Assert.Equal(card1, connection.CardId);
+    }
+
+    [Fact]
+    public async Task GetManyById_FiltersByIconId()
+    {
+        var (card1, card2, icon1, icon2) = await SeedFixtureAsync();
+        var repository = new IconConnectedRepository(_connection);
+        await repository.Insert(new IconConnectedDtoModel { CardId = card1, IconId = icon1 });
+        await repository.Insert(new IconConnectedDtoModel { CardId = card2, IconId = icon2 });
+
+        var result = await repository.GetManyById(null, icon1);
+
+        var connection = Assert.Single(result);
+        Assert.Equal(icon1, connection.IconId);
+    }
+
+    [Fact]
+    public async Task GetManyById_WithNoFilters_ReturnsAllConnections()
+    {
+        var (card1, card2, icon1, icon2) = await SeedFixtureAsync();
+        var repository = new IconConnectedRepository(_connection);
+        await repository.Insert(new IconConnectedDtoModel { CardId = card1, IconId = icon1 });
+        await repository.Insert(new IconConnectedDtoModel { CardId = card2, IconId = icon2 });
+
+        var result = await repository.GetManyById(null, null);
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task Delete_RemovesConnectionsForCard()
+    {
+        var (card1, card2, icon1, icon2) = await SeedFixtureAsync();
+        var repository = new IconConnectedRepository(_connection);
+        await repository.Insert(new IconConnectedDtoModel { CardId = card1, IconId = icon1 });
+        await repository.Insert(new IconConnectedDtoModel { CardId = card2, IconId = icon2 });
+
+        var result = await repository.Delete(card1);
+
+        Assert.True(result);
+        Assert.Empty(await repository.GetManyById(card1, null));
+        Assert.Single(await repository.GetManyById(card2, null));
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        if (File.Exists(_dbPath + ".bak")) File.Delete(_dbPath + ".bak");
+    }
+}

--- a/Tests/Repositories/LocalProversRepositoryTests.cs
+++ b/Tests/Repositories/LocalProversRepositoryTests.cs
@@ -1,0 +1,81 @@
+using System.Data;
+using Gridly.Data;
+using Gridly.Repositories;
+using Microsoft.Data.Sqlite;
+
+namespace Gridly.Tests.Repositories;
+
+public sealed class LocalProversRepositoryTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"gridly-localprovers-{Guid.NewGuid():N}.db");
+    private readonly IDbConnection _connection;
+
+    public LocalProversRepositoryTests()
+    {
+        _connection = new SqliteConnection($"Data Source={_dbPath}");
+    }
+
+    [Fact]
+    public async Task Get_WhenProviderIsNotStored_ReturnsNull()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new LocalProversRepository(_connection);
+
+        var result = await repository.Get("VisualCrossing");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Upsert_WhenProviderIsNew_InsertsKey()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new LocalProversRepository(_connection);
+
+        var result = await repository.Upsert("VisualCrossing", "encrypted-key", "Unknown");
+
+        Assert.True(result);
+        var stored = await repository.Get("VisualCrossing");
+        Assert.NotNull(stored);
+        Assert.Equal("encrypted-key", stored.EncryptedKey);
+        Assert.Equal("Unknown", stored.Status);
+    }
+
+    [Fact]
+    public async Task Upsert_WhenProviderAlreadyExists_UpdatesInPlace()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new LocalProversRepository(_connection);
+        await repository.Upsert("VisualCrossing", "first-key", "Unknown");
+
+        await repository.Upsert("VisualCrossing", "second-key", "Valid");
+
+        var stored = await repository.Get("VisualCrossing");
+        Assert.NotNull(stored);
+        Assert.Equal("second-key", stored.EncryptedKey);
+        Assert.Equal("Valid", stored.Status);
+    }
+
+    [Fact]
+    public async Task UpdateStatus_UpdatesStoredStatus()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new LocalProversRepository(_connection);
+        await repository.Upsert("VisualCrossing", "encrypted-key", "Unknown");
+
+        var result = await repository.UpdateStatus("VisualCrossing", "Invalid");
+
+        Assert.True(result);
+        var stored = await repository.Get("VisualCrossing");
+        Assert.NotNull(stored);
+        Assert.Equal("Invalid", stored.Status);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        if (File.Exists(_dbPath + ".bak")) File.Delete(_dbPath + ".bak");
+    }
+}

--- a/Tests/Repositories/SettingsRepositoryTests.cs
+++ b/Tests/Repositories/SettingsRepositoryTests.cs
@@ -1,0 +1,83 @@
+using System.Data;
+using Dapper;
+using Gridly.Data;
+using Gridly.Models;
+using Gridly.Repositories;
+using Microsoft.Data.Sqlite;
+
+namespace Gridly.Tests.Repositories;
+
+public sealed class SettingsRepositoryTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"gridly-settings-{Guid.NewGuid():N}.db");
+    private readonly IDbConnection _connection;
+
+    public SettingsRepositoryTests()
+    {
+        _connection = new SqliteConnection($"Data Source={_dbPath}");
+    }
+
+    private async Task<int> SeedCardAsync()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var rowColumnId = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO RowColumn (RowPosition, RowWidth) VALUES (1,1); SELECT last_insert_rowid();");
+        var cardId = await _connection.QuerySingleAsync<long>(
+            "INSERT INTO Card (IndexPosition, RowColumnId, Name, Url, Type, IconUrl) VALUES (1, @row, 'A', '', '', ''); SELECT last_insert_rowid();",
+            new { row = rowColumnId });
+        return (int)cardId;
+    }
+
+    [Fact]
+    public async Task Insert_CreatesSettingsAndReturnsGeneratedId()
+    {
+        var cardId = await SeedCardAsync();
+        var repository = new SettingsRepository(_connection);
+
+        var result = await repository.Insert(new SettingsModel { CardId = cardId, Width = 250, Height = 250 });
+
+        Assert.True(result.Id > 0);
+        Assert.Equal(cardId, result.CardId);
+        Assert.Equal(250, result.Width);
+    }
+
+    [Fact]
+    public async Task Edit_UpdatesStoredWidthAndHeight()
+    {
+        var cardId = await SeedCardAsync();
+        var repository = new SettingsRepository(_connection);
+        var inserted = await repository.Insert(new SettingsModel { CardId = cardId, Width = 250, Height = 250 });
+
+        await repository.Edit(new SettingsModel { Id = inserted.Id, CardId = cardId, Width = 500, Height = 400, TitleHidden = true });
+
+        var stored = await _connection.QuerySingleAsync<SettingsModel>(
+            "SELECT Id, CardId, Width, Height, TitleHidden, ImageHidden FROM Settings WHERE CardId = @CardId;",
+            new { CardId = cardId });
+        Assert.Equal(500, stored.Width);
+        Assert.Equal(400, stored.Height);
+        Assert.True(stored.TitleHidden);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesSettingsForCard()
+    {
+        var cardId = await SeedCardAsync();
+        var repository = new SettingsRepository(_connection);
+        await repository.Insert(new SettingsModel { CardId = cardId, Width = 250, Height = 250 });
+
+        var result = await repository.Delete(cardId);
+
+        Assert.True(result);
+        var remaining = await _connection.QuerySingleAsync<int>(
+            "SELECT COUNT(*) FROM Settings WHERE CardId = @CardId;", new { CardId = cardId });
+        Assert.Equal(0, remaining);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        if (File.Exists(_dbPath + ".bak")) File.Delete(_dbPath + ".bak");
+    }
+}

--- a/Tests/Repositories/WidgetRepositoryTests.cs
+++ b/Tests/Repositories/WidgetRepositoryTests.cs
@@ -1,0 +1,41 @@
+using System.Data;
+using Gridly.Data;
+using Gridly.Repositories;
+using Microsoft.Data.Sqlite;
+
+namespace Gridly.Tests.Repositories;
+
+public sealed class WidgetRepositoryTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"gridly-widgets-{Guid.NewGuid():N}.db");
+    private readonly IDbConnection _connection;
+
+    public WidgetRepositoryTests()
+    {
+        _connection = new SqliteConnection($"Data Source={_dbPath}");
+    }
+
+    [Fact]
+    public async Task Get_ReturnsSeededDefaultWidgetsWithJoinedWidgetTypeName()
+    {
+        await new DbInitializer(_connection).EnsureTablesCreatedAsync();
+        var repository = new WidgetRepository(_connection);
+
+        var result = (await repository.Get()).ToList();
+
+        Assert.Equal(3, result.Count);
+        var byType = result.ToDictionary(w => w.WidgetType);
+        Assert.Equal("Weather widget", byType["Weather"].Label);
+        Assert.Equal("clouds", byType["Weather"].Icon);
+        Assert.Equal("Empty widget", byType["Empty"].Label);
+        Assert.Equal("Custom widget", byType["Custom"].Label);
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath)) File.Delete(_dbPath);
+        if (File.Exists(_dbPath + ".bak")) File.Delete(_dbPath + ".bak");
+    }
+}

--- a/Tests/Services/DbConnectionServicesTests.cs
+++ b/Tests/Services/DbConnectionServicesTests.cs
@@ -1,0 +1,65 @@
+using Gridly.Data;
+using Gridly.Tests.Infrastructure;
+using Microsoft.Extensions.Configuration;
+
+namespace Gridly.Tests.Services;
+
+public sealed class DbConnectionServicesTests : IDisposable
+{
+    private readonly string _contentRoot =
+        Path.Combine(Path.GetTempPath(), $"gridly-dbconnection-{Guid.NewGuid():N}");
+
+    [Fact]
+    public void Constructor_WhenConnectionStringIsMissing_ThrowsInvalidOperationException()
+    {
+        var configuration = BuildConfiguration(connectionString: null);
+        var environment = new FakeHostEnvironment { ContentRootPath = _contentRoot };
+
+        Assert.Throws<InvalidOperationException>(() => new DbConnectionServices(configuration, environment));
+    }
+
+    [Fact]
+    public void Constructor_WhenConnectionStringIsValid_CreatesDatabaseDirectoryUnderContentRoot()
+    {
+        var configuration = BuildConfiguration(connectionString: "Data Source=data/gridly.db");
+        var environment = new FakeHostEnvironment { ContentRootPath = _contentRoot };
+
+        _ = new DbConnectionServices(configuration, environment);
+
+        Assert.True(Directory.Exists(Path.Combine(_contentRoot, "data")));
+    }
+
+    [Fact]
+    public void CreateConnection_ReturnsConnectionResolvedUnderContentRoot()
+    {
+        var configuration = BuildConfiguration(connectionString: "Data Source=data/gridly.db");
+        var environment = new FakeHostEnvironment { ContentRootPath = _contentRoot };
+        var service = new DbConnectionServices(configuration, environment);
+
+        using var connection = service.CreateConnection();
+
+        Assert.Equal(Path.Combine(_contentRoot, "data", "gridly.db"), connection.ConnectionString
+            .Split(';')
+            .Select(part => part.Split('=', 2))
+            .First(part => part[0].Equals("Data Source", StringComparison.OrdinalIgnoreCase))[1]);
+    }
+
+    private static IConfiguration BuildConfiguration(string? connectionString)
+    {
+        var values = new Dictionary<string, string?>();
+        if (connectionString is not null)
+        {
+            values["ConnectionStrings:GridlyDb"] = connectionString;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_contentRoot))
+        {
+            Directory.Delete(_contentRoot, recursive: true);
+        }
+    }
+}

--- a/Tests/Services/ProviderKeysProtectionServiceTests.cs
+++ b/Tests/Services/ProviderKeysProtectionServiceTests.cs
@@ -1,0 +1,47 @@
+using Gridly.Services;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Gridly.Tests.Services;
+
+public sealed class ProviderKeysProtectionServiceTests : IDisposable
+{
+    private readonly string _keyRingDirectory =
+        Path.Combine(Path.GetTempPath(), $"gridly-dataprotection-{Guid.NewGuid():N}");
+    private readonly ProviderKeysProtectionService _service;
+
+    public ProviderKeysProtectionServiceTests()
+    {
+        Directory.CreateDirectory(_keyRingDirectory);
+        var provider = DataProtectionProvider.Create(new DirectoryInfo(_keyRingDirectory));
+        _service = new ProviderKeysProtectionService(provider);
+    }
+
+    [Fact]
+    public void Protect_ThenUnprotect_RoundTripsToOriginalValue()
+    {
+        const string rawKey = "super-secret-api-key";
+
+        var protectedValue = _service.Protect(rawKey);
+        var unprotectedValue = _service.Unprotect(protectedValue);
+
+        Assert.Equal(rawKey, unprotectedValue);
+    }
+
+    [Fact]
+    public void Protect_ReturnsValueDifferentFromInput()
+    {
+        const string rawKey = "super-secret-api-key";
+
+        var protectedValue = _service.Protect(rawKey);
+
+        Assert.NotEqual(rawKey, protectedValue);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_keyRingDirectory))
+        {
+            Directory.Delete(_keyRingDirectory, recursive: true);
+        }
+    }
+}

--- a/Tests/Services/WeatherPeriodicRefreshBackgroundServiceTests.cs
+++ b/Tests/Services/WeatherPeriodicRefreshBackgroundServiceTests.cs
@@ -1,0 +1,144 @@
+using Gridly.Dtos;
+using Gridly.EndPoints;
+using Gridly.Enums;
+using Gridly.Repositories;
+using Gridly.Services;
+using Gridly.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Gridly.Tests.Services;
+
+public class WeatherPeriodicRefreshBackgroundServiceTests
+{
+    private static StoredWeatherDataDto MakeStoredEntry(string address = "London") =>
+        new() { Address = address, Timezone = "Europe/London", Description = "", FetchedAt = DateTime.UtcNow };
+
+    [Fact]
+    public async Task RefreshData_WhenNoStoredWeatherData_ReturnsEarlyWithoutCallingEndpoint()
+    {
+        var weatherEndPoint = new FakeWeatherEndPoint();
+        var weatherRepository = new FakeWeatherRepository { StoredWeatherData = null };
+        var localProvidersRepository = new FakeLocalProvidersRepository();
+        var service = CreateService(weatherRepository, weatherEndPoint, localProvidersRepository);
+
+        await service.InvokeRefreshData(CancellationToken.None);
+
+        Assert.Equal(0, weatherEndPoint.GetCallCount);
+    }
+
+    [Fact]
+    public async Task RefreshData_WhenNoProviderKeyStored_ReturnsWithoutCallingEndpoint()
+    {
+        var weatherEndPoint = new FakeWeatherEndPoint();
+        var weatherRepository = new FakeWeatherRepository { StoredWeatherData = [MakeStoredEntry()] };
+        var localProvidersRepository = new FakeLocalProvidersRepository { StoredKey = null };
+        var service = CreateService(weatherRepository, weatherEndPoint, localProvidersRepository);
+
+        await service.InvokeRefreshData(CancellationToken.None);
+
+        Assert.Equal(0, weatherEndPoint.GetCallCount);
+    }
+
+    [Fact]
+    public async Task RefreshData_WhenEndpointReturnsFreshData_UpsertsAndMarksKeyValid()
+    {
+        var days = new[] { new DaysDto(temp: 20, feelslike: 19, humidity: 50, windspeed: 4, windDir: 90) };
+        var weatherDto = new WeatherDataDto("London", "Europe/London", "Sunny", days, DateTime.UtcNow);
+        var weatherEndPoint = new FakeWeatherEndPoint { Result = (StatusCodes.Status200OK, weatherDto) };
+        var weatherRepository = new FakeWeatherRepository { StoredWeatherData = [MakeStoredEntry()] };
+        var localProvidersRepository = new FakeLocalProvidersRepository
+        {
+            StoredKey = new ProviderKeyDtoModel
+            {
+                Provider = "VisualCrossing",
+                EncryptedKey = "raw-key",
+                Status = nameof(ProvidersKeyStatusEnum.Unknown)
+            }
+        };
+        var service = CreateService(weatherRepository, weatherEndPoint, localProvidersRepository);
+
+        await service.InvokeRefreshData(CancellationToken.None);
+
+        Assert.Equal(1, weatherRepository.UpsertCallCount);
+        Assert.Equal(nameof(ProvidersKeyStatusEnum.Valid), localProvidersRepository.LastUpdatedStatus);
+    }
+
+    [Fact]
+    public async Task RefreshData_WhenEndpointThrowsHttpRequestException_MarksKeyInvalidWithoutUpserting()
+    {
+        var weatherEndPoint = new ThrowingWeatherEndPoint(new HttpRequestException("boom"));
+        var weatherRepository = new FakeWeatherRepository { StoredWeatherData = [MakeStoredEntry()] };
+        var localProvidersRepository = new FakeLocalProvidersRepository
+        {
+            StoredKey = new ProviderKeyDtoModel
+            {
+                Provider = "VisualCrossing",
+                EncryptedKey = "raw-key",
+                Status = nameof(ProvidersKeyStatusEnum.Valid)
+            }
+        };
+        var service = CreateService(weatherRepository, weatherEndPoint, localProvidersRepository);
+
+        await service.InvokeRefreshData(CancellationToken.None);
+
+        Assert.Equal(0, weatherRepository.UpsertCallCount);
+        Assert.Equal(nameof(ProvidersKeyStatusEnum.Invalid), localProvidersRepository.LastUpdatedStatus);
+    }
+
+    [Fact]
+    public async Task RefreshData_WhenEndpointThrowsUnexpectedException_SwallowsAndContinues()
+    {
+        var weatherEndPoint = new ThrowingWeatherEndPoint(new InvalidOperationException("boom"));
+        var weatherRepository = new FakeWeatherRepository { StoredWeatherData = [MakeStoredEntry()] };
+        var localProvidersRepository = new FakeLocalProvidersRepository
+        {
+            StoredKey = new ProviderKeyDtoModel
+            {
+                Provider = "VisualCrossing",
+                EncryptedKey = "raw-key",
+                Status = nameof(ProvidersKeyStatusEnum.Valid)
+            }
+        };
+        var service = CreateService(weatherRepository, weatherEndPoint, localProvidersRepository);
+
+        await service.InvokeRefreshData(CancellationToken.None);
+
+        Assert.Equal(0, weatherRepository.UpsertCallCount);
+        Assert.Equal(0, localProvidersRepository.UpdateStatusCallCount);
+    }
+
+    private static TestableWeatherPeriodicRefreshBackgroundService CreateService(
+        IWeatherRepository weatherRepository,
+        IWeatherEndPoint weatherEndPoint,
+        ILocalProvidersRepository localProvidersRepository)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(weatherRepository);
+        services.AddSingleton(weatherEndPoint);
+        services.AddSingleton(localProvidersRepository);
+        var provider = services.BuildServiceProvider();
+
+        var service = new TestableWeatherPeriodicRefreshBackgroundService(
+            NullLogger<WeatherPeriodicRefreshBackgroundService>.Instance,
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            new FakeProviderKeysProtectionService());
+        service.SetDelay((_, _) => Task.CompletedTask);
+        return service;
+    }
+
+    private sealed class TestableWeatherPeriodicRefreshBackgroundService(
+        ILogger<WeatherPeriodicRefreshBackgroundService> logger,
+        IServiceScopeFactory serviceScopeFactory,
+        IProviderKeysProtectionService providerKeysProtectionService)
+        : WeatherPeriodicRefreshBackgroundService(logger, serviceScopeFactory, providerKeysProtectionService)
+    {
+        public Task InvokeRefreshData(CancellationToken cancellationToken) => RefreshData(cancellationToken);
+        public void SetDelay(Func<TimeSpan, CancellationToken, Task> delay) => Delay = delay;
+    }
+
+    private sealed class ThrowingWeatherEndPoint(Exception exception) : IWeatherEndPoint
+    {
+        public Task<(int, WeatherDataDto?)> Get(string address, string rawKey) => throw exception;
+    }
+}

--- a/coverage.runsettings
+++ b/coverage.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!-- App source and tests share one assembly (Gridly.dll), which coverlet otherwise
+               treats as "the test assembly" and skips entirely by default. -->
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+          <Exclude>[Gridly]Gridly.Tests.*,[Gridly]Gridly.Services.HttpClientServices,[Gridly]Program</Exclude>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Adds tests for every previously-untested Handler, Repository, EndPoint, Service, and Factory to raise .NET line coverage to ~81%, all EndPoint tests mocked (no live calls). Fixes an unguarded null-forgiving operator in WeatherDataFactory found while writing its tests. Wires dotnet test in CI to collect coverage via coverlet and fail the build under 80%, since coverlet's own runsettings threshold turned out not to enforce this in collector mode.