### PR TITLE
Move Card Insert repo method to EF Core (#340)

### DIFF
--- a/Constants/QueryStrings.cs
+++ b/Constants/QueryStrings.cs
@@ -7,11 +7,6 @@ public class QueryStrings
     VALUES (@RowPosition, @RowWidth);
     SELECT * FROM RowColumn WHERE Id = last_insert_rowid();";
     
-    public const string InsertToCardQuery = @"
-    INSERT INTO Card (RowColumnId, IndexPosition, Name, Url, IconUrl, Type) 
-    VALUES (@RowColumnId, @IndexPosition, @Name, @Url, @IconUrl, @Type);
-    SELECT * FROM Card WHERE Id = last_insert_rowid();";
-
     public const string InsertToSettingsQuery = @"
     INSERT INTO Settings (CardId, Width, Height, TitleHidden, ImageHidden) 
     VALUES (@CardId, @Width, @Height, @TitleHidden, @ImageHidden);

--- a/Factories/CardFactory.cs
+++ b/Factories/CardFactory.cs
@@ -1,11 +1,24 @@
 using Gridly.Dtos;
+using Gridly.Entities;
 using Gridly.Models;
 
 namespace Gridly.Factories;
 
 public static class CardFactory
 {
-    public static CardModel Create(CardDtoModel dto) 
+    public static CardModel Create(CardEntity entity)
+        => new()
+        {
+            Id = entity.Id,
+            IndexPosition = entity.IndexPosition,
+            RowColumnId = entity.RowColumnId,
+            Name = entity.Name,
+            Url = entity.Url,
+            Type = entity.Type,
+            IconUrl = entity.IconUrl,
+        };
+
+    public static CardModel Create(CardDtoModel dto)
         => new()
         {
             Id = dto.CardId,

--- a/Repositories/CardRepository.cs
+++ b/Repositories/CardRepository.cs
@@ -27,8 +27,7 @@ public class CardRepository(IDbConnection connection, GridlyDbContext dbContext)
         };
         dbContext.Cards.Add(entity);
         await dbContext.SaveChangesAsync();
-        Card.Id = entity.Id;
-        return Card;
+        return Factories.CardFactory.Create(entity);
     }
 
     public async Task<bool> Edit(CardModel Card)

--- a/Repositories/CardRepository.cs
+++ b/Repositories/CardRepository.cs
@@ -3,6 +3,7 @@ using Dapper;
 using Gridly.Constants;
 using Gridly.Data;
 using Gridly.Dtos;
+using Gridly.Entities;
 using Gridly.Models;
 using Gridly.Services;
 using Microsoft.EntityFrameworkCore;
@@ -12,13 +13,24 @@ namespace Gridly.Repositories;
 public class CardRepository(IDbConnection connection, GridlyDbContext dbContext) : ICardRepository
 {
     private DbCommandRunner _dbCommandRunner = new (connection);
-    
+
     public async Task<CardModel> Insert(CardModel Card)
     {
-        return await _dbCommandRunner.Execute(QueryStrings.InsertToCardQuery, Card);
+        var entity = new CardEntity
+        {
+            RowColumnId = Card.RowColumnId!.Value,
+            IndexPosition = Card.IndexPosition!.Value,
+            Name = Card.Name,
+            Url = Card.Url,
+            IconUrl = Card.IconUrl,
+            Type = Card.Type,
+        };
+        dbContext.Cards.Add(entity);
+        await dbContext.SaveChangesAsync();
+        Card.Id = entity.Id;
+        return Card;
     }
-    
-    
+
     public async Task<bool> Edit(CardModel Card)
     {
         var builder = new SqlBuilder();

--- a/Tests/Repositories/CardRepositoryTests.cs
+++ b/Tests/Repositories/CardRepositoryTests.cs
@@ -153,3 +153,40 @@ public sealed class CardRepositoryGetTests : IDisposable
         if (File.Exists(_dbPath + ".bak")) File.Delete(_dbPath + ".bak");
     }
 }
+
+public sealed class CardRepositoryInsertTests
+{
+    [Fact]
+    public async Task Insert_WhenCardIsValid_PersistsRowAndReturnsCardWithGeneratedId()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using var dbContext = new GridlyDbContext(
+            new DbContextOptionsBuilder<GridlyDbContext>().UseSqlite(connection).Options);
+        await dbContext.Database.EnsureCreatedAsync();
+        var repository = new CardRepository(connection, dbContext);
+
+        var card = new CardModel
+        {
+            RowColumnId = 1,
+            IndexPosition = 1,
+            Name = "Docs",
+            Url = "https://example.test",
+            IconUrl = "/icon.svg",
+            Type = "link",
+        };
+
+        var result = await repository.Insert(card);
+
+        Assert.Same(card, result);
+        Assert.NotEqual(0, result.Id);
+
+        var persisted = await dbContext.Cards.SingleAsync(c => c.Id == result.Id);
+        Assert.Equal("Docs", persisted.Name);
+        Assert.Equal("https://example.test", persisted.Url);
+        Assert.Equal("/icon.svg", persisted.IconUrl);
+        Assert.Equal("link", persisted.Type);
+        Assert.Equal(1, persisted.RowColumnId);
+        Assert.Equal(1, persisted.IndexPosition);
+    }
+}

--- a/Tests/Repositories/CardRepositoryTests.cs
+++ b/Tests/Repositories/CardRepositoryTests.cs
@@ -178,8 +178,13 @@ public sealed class CardRepositoryInsertTests
 
         var result = await repository.Insert(card);
 
-        Assert.Same(card, result);
         Assert.NotEqual(0, result.Id);
+        Assert.Equal("Docs", result.Name);
+        Assert.Equal("https://example.test", result.Url);
+        Assert.Equal("/icon.svg", result.IconUrl);
+        Assert.Equal("link", result.Type);
+        Assert.Equal(1, result.RowColumnId);
+        Assert.Equal(1, result.IndexPosition);
 
         var persisted = await dbContext.Cards.SingleAsync(c => c.Id == result.Id);
         Assert.Equal("Docs", persisted.Name);


### PR DESCRIPTION
Continues the CardRepository Dapper-to-EF-Core migration (see #341, #342) for the Insert operation. Adds the entity, saves via GridlyDbContext, and drops InsertToCardQuery from QueryStrings and the repository.