### PR TITLE
Move Card Delete repo method to EF Core (#343)

### DIFF
--- a/Constants/QueryStrings.cs
+++ b/Constants/QueryStrings.cs
@@ -93,7 +93,6 @@ public class QueryStrings
         /**where**/";
 
     public const string DeleteFromSettingsQuery = "DELETE FROM Settings /**where**/";
-    public const string DeleteFromCardQuery = "DELETE FROM Card /**where**/";
     public const string DeleteFromIconsConnectedQuery = "DELETE FROM IconsConnected /**where**/";
     public const string DeleteFromIconQuery = "DELETE FROM Icon /**where**/";
     

--- a/Repositories/CardRepository.cs
+++ b/Repositories/CardRepository.cs
@@ -81,9 +81,9 @@ public class CardRepository(IDbConnection connection, GridlyDbContext dbContext)
 
     public async Task<bool> Delete(int id)
     {
-        var builder = new SqlBuilder();
-        var template = builder.AddTemplate(QueryStrings.DeleteFromCardQuery);
-        builder.Where(QueryStrings.WhereIdEqualsId, new { Id = id });
-        return await _dbCommandRunner.Execute(template.RawSql, template.Parameters);
+        var rowsAffected = await dbContext.Cards
+            .Where(c => c.Id == id)
+            .ExecuteDeleteAsync();
+        return rowsAffected > 0;
     }
 }

--- a/Tests/Repositories/CardRepositoryTests.cs
+++ b/Tests/Repositories/CardRepositoryTests.cs
@@ -195,3 +195,49 @@ public sealed class CardRepositoryInsertTests
         Assert.Equal(1, persisted.IndexPosition);
     }
 }
+
+public sealed class CardRepositoryDeleteTests
+{
+    [Fact]
+    public async Task Delete_WhenCardExists_RemovesRowAndReturnsTrue()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using var dbContext = new GridlyDbContext(
+            new DbContextOptionsBuilder<GridlyDbContext>().UseSqlite(connection).Options);
+        await dbContext.Database.EnsureCreatedAsync();
+        var repository = new CardRepository(connection, dbContext);
+
+        var cardEntity = new CardEntity
+        {
+            IndexPosition = 1,
+            RowColumnId = 1,
+            Name = "Docs",
+            Url = "https://example.test",
+            IconUrl = "/icon.svg",
+            Type = "link",
+        };
+        dbContext.Cards.Add(cardEntity);
+        await dbContext.SaveChangesAsync();
+
+        var result = await repository.Delete(cardEntity.Id);
+
+        Assert.True(result);
+        Assert.False(await dbContext.Cards.AnyAsync(c => c.Id == cardEntity.Id));
+    }
+
+    [Fact]
+    public async Task Delete_WhenCardDoesNotExist_ReturnsFalse()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using var dbContext = new GridlyDbContext(
+            new DbContextOptionsBuilder<GridlyDbContext>().UseSqlite(connection).Options);
+        await dbContext.Database.EnsureCreatedAsync();
+        var repository = new CardRepository(connection, dbContext);
+
+        var result = await repository.Delete(999);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the Dapper/raw-SQL `CardRepository.Delete` with an EF Core `ExecuteDeleteAsync` call, matching the pattern already used for `Insert` (#340) and `Get` (#342)
- Remove the now-unused `DeleteFromCardQuery` constant from `QueryStrings`
- Add `CardRepositoryDeleteTests` covering deleting an existing card and deleting a non-existent id

Closes #343

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — full suite passes (80/80), including the new `CardRepositoryDeleteTests`
